### PR TITLE
ci: attach release binaries before the release is frozen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # release/** so a release branch gets the full suite on its own pushes, and
+    # so the commit a release tag will point at has a successful push run for
+    # release.yml's candidate-ci gate to find.
+    branches: [main, "release/**"]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -14,6 +14,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # This workflow runs on the same tag as release.yml but in its own run, so
+      # it cannot depend on that workflow's immutable-release gate. Repeat the
+      # check here rather than pushing a chart into a release whose binaries can
+      # never be attached. Skipped for workflow_dispatch, where re-publishing a
+      # chart for an already-published release is the point.
+      - name: Fail if the release was already published
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            if [ "$is_draft" != "true" ]; then
+              echo "::error::GitHub Release ${tag} is already published, so release.yml cannot attach its binaries. Refusing to publish the chart into a half-finished release. Delete the release (the tag can stay) and re-run both workflows."
+              exit 1
+            fi
+          fi
+
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -27,11 +27,20 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+          err="${RUNNER_TEMP}/release-view.err"
+
+          # A missing release is the normal case on a fresh tag and means carry
+          # on. Anything else — auth, rate limiting, a 5xx — must not be read as
+          # "no release exists", or this gate waves through exactly the state it
+          # is meant to catch.
+          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>"$err"); then
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub Release ${tag} is already published, so release.yml cannot attach its binaries. Refusing to publish the chart into a half-finished release. Delete the release (the tag can stay) and re-run both workflows."
               exit 1
             fi
+          elif ! grep -qi 'release not found' "$err"; then
+            echo "::error::Could not determine whether release ${tag} is already published, so refusing to publish the chart: $(cat "$err")"
+            exit 1
           fi
 
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,67 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Immutable-release gate
+  # ---------------------------------------------------------------------------
+  # Immutable releases freeze their assets the moment they are published, so the
+  # release has to exist as a draft while the binaries are attached. Publishing
+  # from the GitHub UI creates the tag itself, which means this workflow arrives
+  # to find the release already frozen and cannot attach anything.
+  #
+  # Establishing the draft is therefore the first thing that happens: every
+  # publishing job below waits on it, so that case fails while nothing has
+  # reached crates.io or GHCR. Release by pushing the tag and let this workflow
+  # own the release object.
+  prepare-github-release:
+    name: Prepare draft GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create or verify draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+
+          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            if [ "$is_draft" != "true" ]; then
+              echo "::error::GitHub Release ${tag} is already published, so its assets are immutable and the release binaries cannot be attached. Delete the release (the tag can stay) and re-run this workflow. Release by pushing the tag — this workflow creates the draft, attaches the binaries, and publishes it."
+              exit 1
+            fi
+            echo "Draft release ${tag} already exists; reusing it."
+            exit 0
+          fi
+
+          # Lead the body with this version's changelog entry, the way releases
+          # read before the process moved into this workflow. GitHub appends its
+          # generated "What's Changed" list after it.
+          awk -v section="## [${tag#v}]" '
+            index($0, section) == 1 { inside = 1; next }
+            inside && /^## \[/ { exit }
+            inside { print }
+          ' CHANGELOG.md > release-notes.md
+
+          release_args=(--verify-tag --title "$tag" --generate-notes --draft)
+          if [ -s release-notes.md ]; then
+            release_args+=(--notes-file release-notes.md)
+          else
+            echo "::warning::No CHANGELOG.md section found for ${tag}; using generated notes only."
+          fi
+          if [[ "$tag" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "$tag" "${release_args[@]}"
+
+  # ---------------------------------------------------------------------------
   # Build & push Docker images (multi-arch)
   # ---------------------------------------------------------------------------
   docker-operator:
     name: Docker — Operator
-    needs: [build-binaries]
+    needs: [build-binaries, prepare-github-release]
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: pgroles-operator
@@ -94,7 +150,7 @@ jobs:
 
   docker-cli:
     name: Docker — CLI
-    needs: [build-binaries]
+    needs: [build-binaries, prepare-github-release]
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: pgroles
@@ -278,33 +334,56 @@ jobs:
           path: docker-dist/${{ matrix.binary }}-${{ matrix.target }}
 
   # ---------------------------------------------------------------------------
-  # Create GitHub Release with binaries
+  # Attach binaries to the draft and publish it
   # ---------------------------------------------------------------------------
+  # Runs last, once every other publication has succeeded: publishing the
+  # release is what freezes it, so it doubles as the commit point for the whole
+  # release. If anything above fails, the release stays a draft and can be
+  # deleted and retried.
   github-release:
     name: GitHub Release
-    needs: [build-binaries]
+    needs:
+      - prepare-github-release
+      - build-binaries
+      - docker-operator
+      - docker-cli
+      - publish-crates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: binary-*
           merge-multiple: true
 
-      - name: Create release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          files: "*.tar.gz"
+      - name: Attach binaries to the draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(*.tar.gz)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::No release binaries were downloaded; refusing to publish a release with no assets."
+            exit 1
+          fi
+          for asset in "${assets[@]}"; do
+            gh release upload "${GITHUB_REF_NAME}" "$asset" --clobber
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false
 
   # ---------------------------------------------------------------------------
   # Publish to crates.io
   # ---------------------------------------------------------------------------
   publish-crates:
     name: Publish to crates.io
+    needs: [prepare-github-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,21 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
+          err="${RUNNER_TEMP}/release-view.err"
 
-          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+          # Only an explicit "not found" means there is no release yet. Any other
+          # failure — auth, rate limiting, a 5xx — must not be mistaken for one,
+          # or this gate stops gating.
+          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>"$err"); then
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub Release ${tag} is already published, so its assets are immutable and the release binaries cannot be attached. Delete the release (the tag can stay) and re-run this workflow. Release by pushing the tag — this workflow creates the draft, attaches the binaries, and publishes it."
               exit 1
             fi
             echo "Draft release ${tag} already exists; reusing it."
             exit 0
+          elif ! grep -qi 'release not found' "$err"; then
+            echo "::error::Could not determine whether release ${tag} already exists: $(cat "$err")"
+            exit 1
           fi
 
           # Lead the body with this version's changelog entry, the way releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,41 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  # candidate-ci queries this repository's CI runs.
+  actions: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Exact-commit CI gate
+  # ---------------------------------------------------------------------------
+  # A tag is irreversible the moment crates.io and GHCR are involved, so require
+  # that CI already passed on this exact commit. CI runs automatically on pushes
+  # to main and release/**, so the run this looks for is the one triggered by
+  # merging the release-prep PR — tag that commit once it is green and no manual
+  # dispatch is needed.
+  candidate-ci:
+    name: Verify CI passed on this commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a successful CI run for this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          count=$(gh api -X GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="${EXPECTED_SHA}" \
+            -f event=push \
+            -f status=success \
+            -f per_page=100 \
+            --jq '.total_count')
+          if [ "$count" -lt 1 ]; then
+            echo "::error::No successful CI run exists for ${EXPECTED_SHA}. CI runs automatically on pushes to main and release/**; wait for that run to go green and tag that exact commit. A tag on a commit CI has not passed cannot be released."
+            exit 1
+          fi
+          echo "Found ${count} successful CI run(s) for ${EXPECTED_SHA}."
+
   # ---------------------------------------------------------------------------
   # Immutable-release gate
   # ---------------------------------------------------------------------------
@@ -30,6 +63,7 @@ jobs:
   # own the release object.
   prepare-github-release:
     name: Prepare draft GitHub Release
+    needs: [candidate-ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -226,6 +260,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-binaries:
     name: Build — ${{ matrix.binary }} — ${{ matrix.target }}
+    needs: [candidate-ci]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,50 @@ The heavier fairness/load coverage lives in `.github/workflows/operator-fairness
 - Update affected skills when behavior or public workflows change; avoid
   duplicating canonical skill content elsewhere.
 
-## Release and Containers
+## Release Process
+
+**Release by pushing the tag. Never publish a release from the GitHub UI.**
+
+Publishing from the UI creates the tag itself, so `release.yml` arrives to find
+the release already published — and published releases are immutable, so the CLI
+binaries can never be attached. The workflow creates and publishes the release
+itself; the tag is the only manual step.
+
+1. Open a release-prep PR against `main`: bump `version` in `Cargo.toml`
+   (`workspace.package` plus the `pgroles-core` / `pgroles-inspect`
+   path-dependency pins), refresh `Cargo.lock`, set the chart's `version` and
+   `appVersion`, regenerate the chart README (`scripts/check-helm-docs.sh`), and
+   retitle the changelog's `## [Unreleased]` section to `## [X.Y.Z] - <date>`
+   with a fresh empty `## [Unreleased]` above it.
+2. Merge it once CI is green.
+3. Tag that commit and push:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+The tag push then drives everything, in this order:
+
+1. **`prepare-github-release`** creates a *draft* release, with the body taken
+   from that version's `CHANGELOG.md` section and GitHub's generated "What's
+   Changed" appended. It runs first and every publishing job waits on it, so a
+   release that was published by hand fails here — while nothing has reached
+   crates.io or GHCR.
+2. **`build-binaries`** cross-compiles the CLI for four targets.
+3. **`publish-crates`**, **`docker-operator`**, **`docker-cli`** publish to
+   crates.io and GHCR.
+4. **`github-release`** attaches the tarballs to the draft and publishes it.
+   Publishing is what freezes the release, so it runs last and acts as the
+   commit point for the whole release.
+
+`helm-chart-release.yml` publishes the chart on the same tag in its own run, and
+repeats the "already published" check for the same reason.
+
+If a release run fails, the release stays a draft: delete the draft, fix the
+cause, and re-run. A tag whose run got as far as crates.io or GHCR cannot be
+reused — those publications are irreversible, so cut the next patch version.
+
+## Containers
 
 - Published container images are multi-arch for `linux/amd64` and `linux/arm64`.
 - `.github/workflows/release.yml` builds Linux binaries first, then assembles container images from those artifacts using `docker/Dockerfile.runtime`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,9 +141,19 @@ The tag push then drives everything, in this order:
 `helm-chart-release.yml` publishes the chart on the same tag in its own run, and
 repeats the "already published" check for the same reason.
 
-If a release run fails, the release stays a draft: delete the draft, fix the
-cause, and re-run. A tag whose run got as far as crates.io or GHCR cannot be
-reused — those publications are irreversible, so cut the next patch version.
+When a release run fails, the release stays a draft and nothing is visible to
+users. What to do next depends on how far it got:
+
+- **Failed at `candidate-ci` or `prepare-github-release`** — nothing was
+  published. Delete the draft if one was created, fix the cause, delete and
+  re-push the tag.
+- **Failed after `publish-crates` or a docker job succeeded** — that version is
+  spent. crates.io and GHCR do not allow republishing a version, so re-running
+  the workflow fails on the already-published crates and can never reach
+  `github-release`. Delete the draft and cut the next patch version.
+
+The second case is why the gates run first: everything that can be checked
+cheaply is checked before anything becomes irreversible.
 
 ## Containers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,11 @@ itself; the tag is the only manual step.
    retitle the changelog's `## [Unreleased]` section to `## [X.Y.Z] - <date>`
    with a fresh empty `## [Unreleased]` above it.
 2. Merge it once CI is green.
-3. Tag that commit and push:
+3. **Wait for the CI run that the merge triggered on `main` to pass.** Releasing
+   requires a successful CI run on the exact commit being tagged, and CI runs
+   automatically on pushes to `main` and `release/**`, so this is the run to
+   wait for — no manual dispatch needed.
+4. Tag that green commit and push:
    ```bash
    git checkout main && git pull
    git tag vX.Y.Z && git push origin vX.Y.Z
@@ -120,15 +124,17 @@ itself; the tag is the only manual step.
 
 The tag push then drives everything, in this order:
 
-1. **`prepare-github-release`** creates a *draft* release, with the body taken
+1. **`candidate-ci`** requires a successful CI run for the tagged commit. It
+   runs before anything else, so tagging a commit CI has not passed costs
+   nothing.
+2. **`prepare-github-release`** creates a *draft* release, with the body taken
    from that version's `CHANGELOG.md` section and GitHub's generated "What's
-   Changed" appended. It runs first and every publishing job waits on it, so a
-   release that was published by hand fails here — while nothing has reached
-   crates.io or GHCR.
-2. **`build-binaries`** cross-compiles the CLI for four targets.
-3. **`publish-crates`**, **`docker-operator`**, **`docker-cli`** publish to
+   Changed" appended. Every publishing job waits on it, so a release that was
+   published by hand fails here — while nothing has reached crates.io or GHCR.
+3. **`build-binaries`** cross-compiles the CLI for four targets.
+4. **`publish-crates`**, **`docker-operator`**, **`docker-cli`** publish to
    crates.io and GHCR.
-4. **`github-release`** attaches the tarballs to the draft and publishes it.
+5. **`github-release`** attaches the tarballs to the draft and publishes it.
    Publishing is what freezes the release, so it runs last and acts as the
    commit point for the whole release.
 


### PR DESCRIPTION
## Purpose

`v0.9.0` published to crates.io and GHCR and then failed to attach its CLI tarballs:

```
Found release 0.9.0 (with id=370827861)
##[error]Cannot upload asset pgroles-v0.9.0-x86_64-unknown-linux-musl.tar.gz to an immutable
release. GitHub only allows asset uploads before a release is published, so upload assets to
a draft release before you publish it.
```

The release has `assets: []`. So does `v0.8.0` — the failure had been latent since immutable releases were switched on, and 0.9.0 only surfaced it as a red run.

## Three problems

**The window closes before the binaries exist.** Immutable releases freeze their assets at publish time, so assets have to be attached while the release is still a draft. The release was being published from the GitHub UI, and publishing from the UI is what creates the tag — so `release.yml` always arrived to find the release already frozen. Retrying could never have worked, and `softprops/action-gh-release` has no way to attach to a published release.

**The job graph let the release go out half-finished.** `github-release` had `needs: [build-binaries]` only, so it ran alongside `publish-crates` and the docker jobs rather than after them. The run published four crates and two signed, attested images, and only then discovered it could not complete the release. Every one of those is irreversible. The missing tarballs were the visible symptom; the half-release was the actual defect.

**Nothing checked that the tagged commit was green.** A tag on a commit CI had never passed would publish to crates.io and GHCR just the same.

## Change

Two gates run before anything else, then publication, then the release is published last:

```
candidate-ci  →  prepare-github-release  →  publish-crates    ┐
              →  build-binaries          →  docker-operator   ├→  github-release
                                         →  docker-cli        ┘
```

**`candidate-ci`** requires a successful CI run for the tagged commit. CI runs automatically on pushes to `main` and now `release/**`, so the run it looks for is the one the release-prep merge already triggered — wait for it to go green, then tag that commit. No manual dispatch step.

**`prepare-github-release`** creates the draft. Every publishing job depends on it, so a release that was published by hand fails there — while nothing has left the repository.

**`github-release`** runs last, attaches the tarballs to the draft, and publishes it. Publishing is what freezes the release, so it doubles as the commit point for the whole release: a failure anywhere above leaves a deletable draft rather than a half-published version.

Details worth calling out:

- The draft body is seeded from the version's `CHANGELOG.md` section, with GitHub's generated "What's Changed" appended — exactly what the hand-written release bodies contained. Auto-publishing therefore does not lose the curated notes. Verified the extraction reproduces the 25-line `[0.9.0]` section and stops cleanly at `## [0.8.0]`.
- `github-release` refuses to publish when no tarballs were downloaded, which is the precise shape of the v0.9.0 failure.
- `release.yml` declares an explicit `permissions:` block, so querying workflow runs needs `actions: read` — without it `candidate-ci` would 403 rather than gate.
- `build-binaries` also waits on `candidate-ci`, so tagging an unverified commit fails in seconds instead of after four cross-compiles.

`helm-chart-release.yml` runs on the same tag in a separate workflow run and cannot depend on those gates, so it repeats the published-release check rather than pushing a chart into a release that can never be completed. It is skipped for `workflow_dispatch`, where re-publishing a chart for an already-published release is the intended use.

The draft-gate pattern is adapted from `hardbyte/awa`. The CI gate follows the cleaner variant @hardbyte proposed: accept a successful exact-SHA `push` run rather than requiring a manually dispatched one.

## Docs

`AGENTS.md` gains a **Release Process** section, since the process was not written down anywhere. It leads with the rule that caused this — release by pushing the tag, never publish from the GitHub UI — explains why, and documents the prep-PR checklist, waiting for the post-merge CI run, the job order, and what to do when a run fails. The old "Release and Containers" section keeps its container guidance as **Containers**.

The `skills/` files are user-facing (installing and operating the chart) and per `AGENTS.md` hold product workflows rather than repository contribution rules, so the release process belongs in `AGENTS.md` and they are unchanged.

## Verification

Nothing here is reachable until the next tag push, so this is static checking:

- All three workflows re-parsed as YAML; the resulting `needs:` graph and `permissions:` asserted to be the ones above
- Every new `run:` block syntax-checked with `bash -n`
- Changelog extraction run against the real `CHANGELOG.md` for `v0.9.0`
- `scripts/check-helm-docs.sh` — clean
- `uvx --from skills-ref==0.1.1 agentskills validate skills/pgroles-operator` — valid
- `git diff --check` — clean

## Not in this PR

The `v0.9.0` release itself still has no assets. The four tarballs are still on run [31841772541](https://github.com/hardbyte/pgroles/actions/runs/31841772541) and could be attached to a recreated release, at the cost of a new `published_at` and re-notifying watchers — or 0.9.1 can just pick up the fixed flow. Left as your call.

https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4)_