### PR TITLE
ci: publish the irreversible step last, and gate the chart on CI too

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -9,11 +9,37 @@ on:
 permissions:
   contents: read
   packages: write
+  # The CI gate below queries this repository's workflow runs.
+  actions: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # This workflow publishes on its own, in its own run, so release.yml's
+      # candidate-ci gate does not cover it. Without repeating the check here a
+      # tag on a commit whose CI failed still ships a chart: release.yml aborts,
+      # and this workflow goes right on to package and push.
+      - name: Require a successful CI run for this SHA
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          count=$(gh api -X GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="${EXPECTED_SHA}" \
+            -f event=push \
+            -f status=success \
+            -f per_page=100 \
+            --jq '.total_count')
+          if [ "$count" -lt 1 ]; then
+            echo "::error::No successful CI run exists for ${EXPECTED_SHA}, so refusing to publish the chart. CI runs automatically on pushes to main and release/**; wait for that run to go green and tag that exact commit."
+            exit 1
+          fi
+          echo "Found ${count} successful CI run(s) for ${EXPECTED_SHA}."
+
       # This workflow runs on the same tag as release.yml but in its own run, so
       # it cannot depend on that workflow's immutable-release gate. Repeat the
       # check here rather than pushing a chart into a release whose binaries can

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,9 +423,15 @@ jobs:
   # ---------------------------------------------------------------------------
   # Publish to crates.io
   # ---------------------------------------------------------------------------
+  # Runs after the images rather than beside them, because this is the one step
+  # that cannot be undone. A GHCR package version can be deleted and a draft
+  # release discarded, but a crates.io version can only be yanked — the number is
+  # spent either way. Publishing here last means a docker failure no longer burns
+  # four crate versions on a release that never completes, and leaves only the
+  # attach-and-publish step after it.
   publish-crates:
     name: Publish to crates.io
-    needs: [prepare-github-release]
+    needs: [prepare-github-release, docker-operator, docker-cli]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,14 +132,23 @@ The tag push then drives everything, in this order:
    Changed" appended. Every publishing job waits on it, so a release that was
    published by hand fails here — while nothing has reached crates.io or GHCR.
 3. **`build-binaries`** cross-compiles the CLI for four targets.
-4. **`publish-crates`**, **`docker-operator`**, **`docker-cli`** publish to
-   crates.io and GHCR.
-5. **`github-release`** attaches the tarballs to the draft and publishes it.
+4. **`docker-operator`** and **`docker-cli`** push, sign, and attest the images.
+5. **`publish-crates`** publishes the four crates, after the images rather than
+   beside them. It is the one step that cannot be undone — a GHCR package
+   version can be deleted and a draft release discarded, but a crates.io version
+   can only be yanked — so it goes as late as possible.
+6. **`github-release`** attaches the tarballs to the draft and publishes it.
    Publishing is what freezes the release, so it runs last and acts as the
    commit point for the whole release.
 
-`helm-chart-release.yml` publishes the chart on the same tag in its own run, and
-repeats the "already published" check for the same reason.
+`helm-chart-release.yml` publishes the chart on the same tag in its own run. It
+cannot depend on the jobs above, so it repeats both gates itself — the CI check
+and the already-published check.
+
+None of this is atomic: crates.io, GHCR, and the chart are three registries, and
+the crates publish four times in sequence. A failure between any two of them
+leaves a gap no workflow can close. The ordering only ensures nothing publishes
+from a commit CI has not passed, and that the irreversible step happens last.
 
 When a release run fails, the release stays a draft and nothing is visible to
 users. What to do next depends on how far it got:


### PR DESCRIPTION
Follow-up to #170. Stacked on it, so review after that merges — the diff here is the last commit.

Two gaps that #170's ordering left open.

## crates.io could be burned by a docker failure

`publish-crates` ran in parallel with the docker jobs, and it is the faster of the two — a couple of minutes against a multi-arch build, sign, and attest. So the usual shape of a docker failure was: four crate versions already published, for a release that then never completes.

That matters because the steps are not equally recoverable:

| | Recoverable? |
|---|---|
| Draft GitHub release | Yes — delete it |
| GHCR image / chart version | Mostly — package versions can be deleted, with limits on popular public packages |
| crates.io version | **No** — yank only; the number is spent either way |

`publish-crates` now waits on both docker jobs, so the one irreversible step happens after everything else has succeeded, leaving only the attach-and-publish after it:

```
candidate-ci  →  prepare-github-release  →  docker-operator  ┐
              →  build-binaries          →  docker-cli       ┴→  publish-crates  →  github-release
```

## A red commit still shipped a Helm chart

`helm-chart-release.yml` checked whether the release was already published, but never checked CI — and it publishes from its own workflow run, so #170's `candidate-ci` gate does not cover it. Tagging a commit whose CI failed aborted `release.yml` at the gate while the chart workflow went right on to verify the chart version, check CRD drift, and push the chart to GHCR.

It now repeats the same exact-SHA CI check. That needs `actions: read` alongside its existing `contents: read` / `packages: write`, since the workflow declares an explicit permissions block.

## What this does not fix

The release still is not atomic, and cannot be. crates.io, GHCR, and the chart are three independent registries, and the crates publish four times in sequence — a failure between any two leaves a gap. In particular a `publish-crates` failure partway through (crate three of four) still strands the earlier ones, and cutting the next patch version remains the only recovery.

The ordering buys two narrower things: nothing publishes from a commit CI has not passed, and the step that cannot be undone happens last. `AGENTS.md` now states that limit explicitly rather than implying the ordering closes every gap.

## Verification

Static, as with #170 — none of this is reachable until a tag push:

- Both workflows re-parsed as YAML; `needs:` graph and `permissions:` asserted to be the ones above
- New `run:` block syntax-checked with `bash -n`
- `git diff --check` — clean

https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4)_