### PR TITLE
docs: correct stale claims, cut duplication, and orient the tutorials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,9 @@ diff(current, effective desired) → Vec<Change> → sql::render_all_with_contex
 - **Unit Tests** — `cargo test --workspace`
 - **Integration Tests** — PG 16/17/18 matrix, `cargo test --workspace -- --include-ignored`
 - **Docker and example smoke tests** — verifies the documented container and example flows work end-to-end
-- **Operator E2E** — kind cluster, deploys the operator plus an OpenTelemetry Collector, runs happy-path plus conflict/invalid/missing-secret/insufficient-privilege/secret-rotation scenarios, verifies larger generated policy convergence at higher object counts, verifies roles in the database, and verifies OTLP metrics export
-- **Plan lifecycle and load E2E** — plan approval flows, and generated-policy plus ephemeral-request load
-- **Ephemeral access E2E** — a two-way matrix over the trusted-writer posture and the Kyverno secure-admission profile in `k8s/security/`
+- **Operator E2E** — kind cluster, deploys the operator plus an OpenTelemetry Collector, runs happy-path plus conflict/invalid/missing-secret/insufficient-privilege/secret-rotation scenarios, verifies roles in the database, and verifies OTLP metrics export
+- **Plan lifecycle and load E2E** — plan approval flows, plus generated-policy convergence at higher object counts and ephemeral-request load
+- **Ephemeral access E2E** — runs twice: once for the trusted-writer posture, once for the Kyverno secure-admission profile in `k8s/security/`
 
 The heavier fairness/load coverage lives in `.github/workflows/operator-fairness-load.yml` and runs on a nightly schedule when `main` has changed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,13 @@ docker run --rm --name pgroles-pg16 \
 YAML → parse_manifest() → PolicyManifest
      → expand_manifest() → ExpandedManifest (profiles × schemas resolved)
      → RoleGraph::from_expanded() → RoleGraph (desired)
+     → [operator only] compose_effective_graph() → RoleGraph (effective desired)
+       overlays memberships from active EphemeralAccessRequests
 
 DB   → inspect() → RoleGraph (current)
      → detect_pg_version() → SqlContext
 
-diff(current, desired) → Vec<Change> → sql::render_all_with_context() → SQL
+diff(current, effective desired) → Vec<Change> → sql::render_all_with_context() → SQL
 ```
 
 ### Workspace Crates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,18 @@ cargo test --workspace -- --include-ignored
 # Run a single test
 cargo test -p pgroles-core --lib diff::tests::diff_creates_new_roles -- --exact
 
-# CRD drift check (CI enforces all four committed CRD copies match crdgen output)
+# CRD drift check (CI compares all eight committed copies against crdgen output:
+# the four in the chart, and the four standalone manifests in k8s/)
 scripts/check-crd-drift.sh
 
-# Regenerate CRDs after modifying crd.rs (writes both CRDs; the four committed
-# copies must match, which is what check-crd-drift.sh compares)
+# Regenerate CRDs after modifying crd.rs. crdgen writes all four kinds into the
+# chart; the k8s/ copies are duplicates that must be refreshed by hand, and
+# check-crd-drift.sh fails if any of the eight drifts.
 cargo run --bin crdgen -- --output-dir charts/pgroles-operator/crds/
 cp charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml k8s/crd.yaml
 cp charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml k8s/postgrespolicyplan-crd.yaml
+cp charts/pgroles-operator/crds/ephemeralaccesspolicies.pgroles.io.yaml k8s/ephemeralaccesspolicy-crd.yaml
+cp charts/pgroles-operator/crds/ephemeralaccessrequests.pgroles.io.yaml k8s/ephemeralaccessrequest-crd.yaml
 ```
 
 ### Local PostgreSQL for integration tests
@@ -76,12 +80,15 @@ diff(current, effective desired) → Vec<Change> → sql::render_all_with_contex
 
 ## CI
 
-Five jobs in `.github/workflows/ci.yml`:
-1. **Lint** — `cargo fmt --check`, `clippy -D warnings`, CRD drift check
-2. **Unit Tests** — `cargo test --workspace`
-3. **Integration Tests** — PG 16/17/18 matrix, `cargo test --workspace -- --include-ignored`
-4. **Docker Smoke Tests** — verifies the documented container flows work end-to-end
-5. **E2E** — kind cluster, deploys operator plus an OpenTelemetry Collector, runs happy-path plus conflict/invalid/missing-secret/insufficient-privilege/secret-rotation operator scenarios, verifies larger generated policy convergence at higher object counts, verifies roles in database, and verifies OTLP metrics export
+`.github/workflows/ci.yml` runs:
+
+- **Lint** — `cargo fmt --check`, `clippy -D warnings`, CRD drift check, helm-docs drift check
+- **Unit Tests** — `cargo test --workspace`
+- **Integration Tests** — PG 16/17/18 matrix, `cargo test --workspace -- --include-ignored`
+- **Docker and example smoke tests** — verifies the documented container and example flows work end-to-end
+- **Operator E2E** — kind cluster, deploys the operator plus an OpenTelemetry Collector, runs happy-path plus conflict/invalid/missing-secret/insufficient-privilege/secret-rotation scenarios, verifies larger generated policy convergence at higher object counts, verifies roles in the database, and verifies OTLP metrics export
+- **Plan lifecycle and load E2E** — plan approval flows, and generated-policy plus ephemeral-request load
+- **Ephemeral access E2E** — a two-way matrix over the trusted-writer posture and the Kyverno secure-admission profile in `k8s/security/`
 
 The heavier fairness/load coverage lives in `.github/workflows/operator-fairness-load.yml` and runs on a nightly schedule when `main` has changed.
 

--- a/docs/markdoc/tags.js
+++ b/docs/markdoc/tags.js
@@ -2,6 +2,7 @@ import { Callout } from '@/components/Callout'
 import { OperatorArchitectureDiagram } from '@/components/OperatorArchitectureDiagram'
 import { OperatorReconciliationDiagram } from '@/components/OperatorReconciliationDiagram'
 import { QuickLink, QuickLinks } from '@/components/QuickLinks'
+import { RoleGraphDiagram } from '@/components/RoleGraphDiagram'
 import { WorkspaceDataFlowDiagram } from '@/components/WorkspaceDataFlowDiagram'
 
 const tags = {
@@ -52,6 +53,10 @@ const tags = {
   'operator-reconciliation-diagram': {
     selfClosing: true,
     render: OperatorReconciliationDiagram,
+  },
+  'role-graph-diagram': {
+    selfClosing: true,
+    render: RoleGraphDiagram,
   },
   'workspace-data-flow-diagram': {
     selfClosing: true,

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -17,7 +17,6 @@ const navigation = [
         links: [
             {title: 'Getting started', href: '/'},
             {title: 'Quick start', href: '/docs/quick-start'},
-            {title: 'Related tools', href: '/docs/alternatives'},
         ],
     },
     {
@@ -48,6 +47,7 @@ const navigation = [
             {title: 'Default privileges', href: '/docs/default-privileges'},
             {title: 'Memberships', href: '/docs/memberships'},
             {title: 'Bundle composition', href: '/docs/bundle-composition'},
+            {title: 'Application access patterns', href: '/docs/tooling'},
             {title: 'Manifest reference', href: '/docs/manifest-reference'},
         ],
     },
@@ -66,7 +66,6 @@ const navigation = [
             {title: 'Install the CLI', href: '/docs/installation'},
             {title: 'CLI commands', href: '/docs/cli'},
             {title: 'CI/CD integration', href: '/docs/ci-cd'},
-            {title: 'Application access patterns', href: '/docs/tooling'},
         ],
     },
     {
@@ -74,6 +73,7 @@ const navigation = [
         links: [
             {title: 'Architecture', href: '/docs/architecture'},
             {title: 'Limitations', href: '/docs/limitations'},
+            {title: 'Related tools', href: '/docs/alternatives'},
         ],
     },
 ]

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -16,7 +16,8 @@ const navigation = [
         title: 'Introduction',
         links: [
             {title: 'Getting started', href: '/'},
-            {title: 'Quick start', href: '/docs/quick-start'},
+            {title: 'CLI quick start', href: '/docs/quick-start'},
+            {title: 'Operator quick start', href: '/docs/operator-quick-start'},
         ],
     },
     {

--- a/docs/src/components/OperatorArchitectureDiagram.jsx
+++ b/docs/src/components/OperatorArchitectureDiagram.jsx
@@ -16,8 +16,9 @@ export function OperatorArchitectureDiagram() {
           <p className="m-0 text-xs font-semibold uppercase tracking-[0.2em] text-teal-800 dark:text-teal-300">
             Kubernetes API
           </p>
-          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <DiagramChip title="PostgresPolicy" subtitle="generation changes" tone="teal" />
+            <DiagramChip title="EphemeralAccessRequest" subtitle="request lifecycle" tone="teal" />
             <DiagramChip title="Secret" subtitle="resourceVersion changes" tone="amber" />
             <DiagramChip title="Status" subtitle="conditions and summary" tone="stone" />
           </div>
@@ -49,6 +50,8 @@ export function OperatorArchitectureDiagram() {
               tone="teal"
               items={[
                 'PostgresPolicy generation updates',
+                'PostgresPolicyPlan approval changes',
+                'EphemeralAccessRequest lifecycle changes',
                 'Referenced Secret changes',
                 'Interval-based requeues',
               ]}
@@ -62,6 +65,7 @@ export function OperatorArchitectureDiagram() {
                 'Fetch Secret and refresh sqlx pool',
                 'Convert CRD to PolicyManifest',
                 'Expand profiles and schemas',
+                'Overlay active ephemeral grants',
                 'Inspect PostgreSQL',
                 'Diff current vs desired state',
                 'Apply SQL in one transaction',

--- a/docs/src/components/OperatorArchitectureDiagram.jsx
+++ b/docs/src/components/OperatorArchitectureDiagram.jsx
@@ -51,7 +51,6 @@ export function OperatorArchitectureDiagram() {
               items={[
                 'PostgresPolicy generation updates',
                 'PostgresPolicyPlan approval changes',
-                'EphemeralAccessRequest lifecycle changes',
                 'Referenced Secret changes',
                 'Interval-based requeues',
               ]}

--- a/docs/src/components/OperatorArchitectureDiagram.jsx
+++ b/docs/src/components/OperatorArchitectureDiagram.jsx
@@ -18,7 +18,12 @@ export function OperatorArchitectureDiagram() {
           </p>
           <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <DiagramChip title="PostgresPolicy" subtitle="generation changes" tone="teal" />
-            <DiagramChip title="EphemeralAccessRequest" subtitle="request lifecycle" tone="teal" />
+            <DiagramChip title="PostgresPolicyPlan" subtitle="approval changes" tone="teal" />
+            <DiagramChip
+              title="EphemeralAccessRequest"
+              subtitle="own controller, own locks"
+              tone="teal"
+            />
             <DiagramChip title="Secret" subtitle="resourceVersion changes" tone="amber" />
             <DiagramChip title="Status" subtitle="conditions and summary" tone="stone" />
           </div>

--- a/docs/src/components/RoleGraphDiagram.jsx
+++ b/docs/src/components/RoleGraphDiagram.jsx
@@ -48,17 +48,12 @@ export function RoleGraphDiagram() {
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        <div className="mt-6 grid gap-4">
           <GraphNote title="No membership edges yet">
             This manifest declares no <span className="font-mono">memberships</span>, so{' '}
             <span className="font-mono">analytics</span> holds every privilege directly. When you do
             add one, the edge runs <span className="font-mono">member -&gt; role</span>: the member
             inherits the privileges of the role it is granted, never the other way around.
-          </GraphNote>
-          <GraphNote title="default_owner: app_owner">
-            The default owner is the object-creator context for{' '}
-            <span className="font-mono">ALTER DEFAULT PRIVILEGES</span>. This manifest defines no
-            default privileges yet, so it stays unused until you add them.
           </GraphNote>
         </div>
       </div>

--- a/docs/src/components/RoleGraphDiagram.jsx
+++ b/docs/src/components/RoleGraphDiagram.jsx
@@ -1,0 +1,169 @@
+export function RoleGraphDiagram() {
+  return (
+    <div className="not-prose my-10 overflow-hidden rounded-[2rem] border border-stone-300/90 bg-[linear-gradient(180deg,#fff,rgba(245,245,244,0.96))] shadow-[0_26px_70px_-44px_rgba(28,25,23,0.35)] dark:border-stone-700 dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.96),rgba(17,24,39,0.9))] dark:shadow-none">
+      <div className="border-b border-stone-300/80 bg-white/90 px-6 py-4 backdrop-blur dark:border-stone-700 dark:bg-stone-900/85">
+        <p className="m-0 font-display text-lg text-stone-900 dark:text-white">
+          The role graph you are about to build
+        </p>
+        <p className="mt-1 text-sm text-stone-600 dark:text-stone-400">
+          One login role, <span className="font-mono">analytics</span>, granted read-only access to
+          the <span className="font-mono">public</span> schema in{' '}
+          <span className="font-mono">mydb</span>.
+        </p>
+      </div>
+
+      <div className="px-5 py-6 sm:px-6">
+        <div className="grid items-center gap-4 xl:grid-cols-[minmax(0,0.9fr),auto,minmax(0,1.4fr)]">
+          <RoleNode
+            eyebrow="Role"
+            name="analytics"
+            comment="Analytics read-only role"
+            attributes={['LOGIN']}
+          />
+
+          <EdgeArrow label="is granted" />
+
+          <div className="grid min-w-0 gap-3">
+            <GrantNode
+              privilege="CONNECT"
+              objectType="Database"
+              objectName="mydb"
+              body="Lets the role open a connection to the database."
+              tone="teal"
+            />
+            <GrantNode
+              privilege="USAGE"
+              objectType="Schema"
+              objectName="public"
+              body="Lets the role reach the objects that live inside the schema."
+              tone="stone"
+            />
+            <GrantNode
+              privilege="SELECT"
+              objectType="Tables"
+              objectName="public.*"
+              body="Read-only access to every table currently in the schema."
+              tone="amber"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          <GraphNote title="No membership edges yet">
+            This manifest declares no <span className="font-mono">memberships</span>, so{' '}
+            <span className="font-mono">analytics</span> holds every privilege directly. When you do
+            add one, the edge runs <span className="font-mono">member -&gt; role</span>: the member
+            inherits the privileges of the role it is granted, never the other way around.
+          </GraphNote>
+          <GraphNote title="default_owner: app_owner">
+            The default owner is the object-creator context for{' '}
+            <span className="font-mono">ALTER DEFAULT PRIVILEGES</span>. This manifest defines no
+            default privileges yet, so it stays unused until you add them.
+          </GraphNote>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RoleNode({ eyebrow, name, comment, attributes }) {
+  return (
+    <div className="min-w-0 rounded-[1.6rem] border border-teal-200/80 bg-teal-50/55 p-5 shadow-[0_16px_34px_-28px_rgba(28,25,23,0.4)] dark:border-teal-900/60 dark:bg-teal-950/20 dark:shadow-none">
+      <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+        {eyebrow}
+      </p>
+      <p className="mt-2 break-words font-mono text-xl text-stone-900 dark:text-white">{name}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {attributes.map((attribute) => (
+          <span
+            key={attribute}
+            className="rounded-full border border-teal-200 bg-white px-3 py-1 font-mono text-xs text-teal-800 dark:border-teal-900/60 dark:bg-stone-900/80 dark:text-teal-200"
+          >
+            {attribute}
+          </span>
+        ))}
+      </div>
+      <p className="mt-4 text-sm leading-6 text-stone-700 dark:text-stone-300">{comment}</p>
+    </div>
+  )
+}
+
+function EdgeArrow({ label }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-1">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 48"
+        className="h-10 w-5 text-teal-500 dark:text-teal-400 xl:hidden"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 2v38" />
+        <path d="M6 34l6 10 6-10" />
+      </svg>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 48 24"
+        className="hidden h-5 w-10 text-teal-500 dark:text-teal-400 xl:block"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M2 12h38" />
+        <path d="M34 6l10 6-10 6" />
+      </svg>
+      <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+        {label}
+      </p>
+    </div>
+  )
+}
+
+function GrantNode({ privilege, objectType, objectName, body, tone }) {
+  const tones = {
+    teal: 'border-teal-200/80 bg-white dark:border-teal-900/60 dark:bg-stone-900/85',
+    stone: 'border-stone-300/90 bg-white dark:border-stone-700 dark:bg-stone-900/85',
+    amber: 'border-amber-200/80 bg-white dark:border-amber-900/60 dark:bg-stone-900/85',
+  }
+
+  const chips = {
+    teal: 'border-teal-200 bg-teal-50/80 text-teal-800 dark:border-teal-900/60 dark:bg-teal-950/30 dark:text-teal-200',
+    stone:
+      'border-stone-300 bg-stone-50 text-stone-800 dark:border-stone-700 dark:bg-stone-950/40 dark:text-stone-200',
+    amber:
+      'border-amber-200 bg-amber-50/80 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200',
+  }
+
+  return (
+    <div
+      className={`min-w-0 rounded-[1.5rem] border p-4 shadow-[0_14px_28px_-24px_rgba(28,25,23,0.35)] dark:shadow-none ${tones[tone]}`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`rounded-full border px-3 py-1 font-mono text-xs ${chips[tone]}`}>
+          {privilege}
+        </span>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+          {objectType}
+        </span>
+        <span className="break-all font-mono text-sm text-stone-900 dark:text-white">
+          {objectName}
+        </span>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-stone-700 dark:text-stone-300">{body}</p>
+    </div>
+  )
+}
+
+function GraphNote({ title, children }) {
+  return (
+    <div className="rounded-[1.5rem] border border-stone-300/90 bg-white/90 p-4 shadow-[0_14px_28px_-24px_rgba(28,25,23,0.35)] dark:border-stone-700 dark:bg-stone-900/80 dark:shadow-none">
+      <p className="m-0 font-display text-lg text-stone-900 dark:text-white">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-stone-700 dark:text-stone-300">{children}</p>
+    </div>
+  )
+}

--- a/docs/src/pages/docs/ephemeral-access.md
+++ b/docs/src/pages/docs/ephemeral-access.md
@@ -10,8 +10,9 @@ Three resources are involved. A `PostgresPolicy` remains the durable source of
 truth for who has standing access. An `EphemeralAccessPolicy` defines a bundle
 of memberships that may be requested against that policy, and the ceilings on
 how long a grant may last. Each `EphemeralAccessRequest` is one immutable record
-of a single grant: who asked, for which subject, for how long, who approved it,
-and when it ended.
+of one access request: who asked, for which subject, for how long, who approved
+or refused it, and how it ended. Not every request becomes a grant — it can be
+denied, or expire before anyone decides.
 
 Two mechanisms are involved, and it is worth keeping them apart. The request
 controller performs the grant itself, executing scoped membership SQL under the
@@ -187,9 +188,15 @@ Two further phases exist in the API but will not be seen in `status.phase`.
 `Revoked` describes deletion, and is written to the audit stream and the request's
 Events but deliberately not to an object whose finalizer is about to be removed —
 so deletion never passes through `Revoking` either. `Failed` is defined and
-classified as a warning, but no code path currently sets it: an activation or
-revocation error leaves the phase alone and records `status.lastError` while the
-reconcile retries. Alert on `lastError`, not on `phase: Failed`.
+classified as a warning, but no code path currently sets it.
+
+That makes failure slightly awkward to watch for. A request whose bundle cannot
+be resolved or validated records the reason in `status.lastError` and retries.
+An activation or revocation error does neither: the phase is left alone,
+`lastError` is not written, the error is logged, and the scoped
+`PostgresPolicyPlan` for that request records the failure. So the signal is a
+request that stops advancing — sitting in `Applying` or `Revoking` — rather than
+any phase or field on the request itself.
 
 `Ended` does not always mean the memberships were revoked. When a membership has
 become part of the durable `PostgresPolicy` in the meantime it is kept and
@@ -199,7 +206,7 @@ request still needs them are left in place without being recorded there.
 Alongside the phase, `status` carries `approvalExpiresAt`, `activatedAt`,
 `expiresAt`, `endedAt`, and `lastError`.
 
-Requests emit their own Kubernetes Events, so `kubectl describe
+Requests emit their own Kubernetes Events, so `kubectl describe -n <namespace>
 ephemeralaccessrequest <name>` shows one request's history directly.
 
 ## Expiry and deletion
@@ -216,8 +223,9 @@ fresh duration after restart.
 
 Suspending an access policy blocks new activation while active requests run to
 their existing expiry. Deleting an access policy deletes and revokes its
-requests before the policy finalizer completes. Do not force-remove finalizers —
-that strands the membership in PostgreSQL with no request left to revoke it.
+requests before the policy finalizer completes. Do not force-remove an active
+request's finalizer — that is the one that bypasses revocation, stranding the
+membership in PostgreSQL with no request left to take it back.
 Authoritative reconciliation of the durable policy can later remove the stray
 edge; additive mode may leave it indefinitely.
 

--- a/docs/src/pages/docs/ephemeral-access.md
+++ b/docs/src/pages/docs/ephemeral-access.md
@@ -13,9 +13,14 @@ how long a grant may last. Each `EphemeralAccessRequest` is one immutable record
 of a single grant: who asked, for which subject, for how long, who approved it,
 and when it ended.
 
-The operator overlays active grants onto the durable policy's desired role graph
-at reconcile time, so an ephemeral membership is real PostgreSQL state without
-ever being written into the `PostgresPolicy`.
+Two mechanisms are involved, and it is worth keeping them apart. The request
+controller performs the grant itself, executing scoped membership SQL under the
+same per-database locks the durable policy uses — that is what makes the access
+real. Separately, when a `PostgresPolicy` reconciles, active ephemeral
+memberships are composed onto its desired role graph, so authoritative
+reconciliation sees them as intended state instead of revoking them as drift.
+The grant happens without the `PostgresPolicy` ever being edited; the overlay is
+what stops the next reconcile from undoing it.
 
 The feature does not issue credentials or implement cloud login — the subject
 must already exist as a PostgreSQL role.

--- a/docs/src/pages/docs/ephemeral-access.md
+++ b/docs/src/pages/docs/ephemeral-access.md
@@ -4,19 +4,27 @@ description: Request, approve, and revoke bounded PostgreSQL role memberships.
 ---
 
 Ephemeral access grants an existing PostgreSQL identity one predefined bundle of
-role memberships for a bounded duration. `PostgresPolicy` remains the durable
-source of truth; an `EphemeralAccessPolicy` defines a requestable bundle, and an
-immutable `EphemeralAccessRequest` records one request lifecycle.
+role memberships for a bounded duration, then takes it back.
 
-The feature does not issue credentials, implement cloud login, or terminate
-existing sessions. Revoking membership prevents a new `SET ROLE`, but a session
-which already assumed the role can retain it until it resets or disconnects.
+Three resources are involved. A `PostgresPolicy` remains the durable source of
+truth for who has standing access. An `EphemeralAccessPolicy` defines a bundle
+of memberships that may be requested against that policy, and the ceilings on
+how long a grant may last. Each `EphemeralAccessRequest` is one immutable record
+of a single grant: who asked, for which subject, for how long, who approved it,
+and when it ended.
 
-{% callout type="warning" title="Choose a trust model before enabling requests" %}
-Direct Kubernetes API access needs admission enforcement; a trusted broker must
-authenticate callers and be the only non-controller writer. pgroles ships a
-CI-tested Kyverno reference implementation, but Kyverno is not part of the
-operator itself. See [securing ephemeral access](/docs/ephemeral-access-security).
+The operator overlays active grants onto the durable policy's desired role graph
+at reconcile time, so an ephemeral membership is real PostgreSQL state without
+ever being written into the `PostgresPolicy`.
+
+The feature does not issue credentials or implement cloud login — the subject
+must already exist as a PostgreSQL role.
+
+{% callout type="warning" title="Requests need a trust boundary before you enable them" %}
+Anyone who can create requests can grant themselves the bundle, and `Required`
+approval is only a real boundary under admission enforcement or a trusted
+broker. Read [securing ephemeral access](/docs/ephemeral-access-security) before
+allowing requests in a cluster that matters.
 {% /callout %}
 
 ## Define a requestable bundle
@@ -51,10 +59,15 @@ not create a login identity for a request. Ephemeral memberships never include
 another role. Durations are one or more integer/unit pairs using `s`, `m`, or
 `h` (for example `45s` or `1h30m`); unitless values are rejected.
 
-Ephemeral access requires PostgreSQL 16 or later so that `inherit` is enforced
-on each membership. Setting `inherit: false` creates set-role-only access: the
-subject must explicitly run `SET ROLE`, rather than inheriting the granted
-role's privileges immediately.
+Setting `inherit: false` creates set-role-only access: the subject must
+explicitly run `SET ROLE` rather than inheriting the granted role's privileges
+immediately.
+
+Per-membership `inherit` needs PostgreSQL 16 or later. On PostgreSQL 15 and
+earlier the option cannot be encoded per grant, so a membership is accepted only
+when its `inherit` already matches the subject role's global `INHERIT`; a
+mismatch is rejected naming both values. Set-role-only access on those versions
+therefore requires a globally `NOINHERIT` subject.
 
 `pendingRequestTTL` defaults to `15m` when omitted: a request that is not
 approved within that window becomes `ApprovalExpired` and cannot be revived.
@@ -94,13 +107,12 @@ spec:
   justification: Investigating INC-1234
 ```
 
-`requestedBy` is required so every request is self-describing. It is trustworthy
-only when an admission policy derives it from the authenticated Kubernetes
-caller or a trusted broker supplies it after authenticating the requester. The
-supplied Kyverno reference policy replaces the submitted username, UID, and
-groups with admission `userInfo`. Its `use` check authorizes the bundle, not a
-mapping from the caller to `subject.role`; restrict requesters accordingly or
-add that identity mapping in admission.
+`requestedBy` is required so every request is self-describing, but the API
+server does not verify it — a caller writing this YAML can put any name in it.
+It becomes trustworthy only under the enforcement described in
+[securing ephemeral access](/docs/ephemeral-access-security), which also covers
+why holding `use` does not by itself constrain which `subject.role` a requester
+may name.
 
 The request spec is immutable. The operator resolves concrete memberships into
 write-once `status.resolvedAccess`, including the target and access-policy UIDs,
@@ -143,12 +155,36 @@ hash and duration. The condition and `status.decidedBy` are recorded together:
 ]
 ```
 
-The Kyverno reference policy overwrites `decidedBy` with authenticated admission
-`userInfo`. A trusted broker must set it from its authenticated decision maker.
-The CRD makes the decision and identity terminal, while the deployment's
-security boundary determines whether that identity is authoritative. See
-[securing ephemeral access](/docs/ephemeral-access-security) for the required
-controls and tested manifests.
+The CRD makes the decision and the identity terminal — neither can be rewritten
+once set. Whether that identity is *authoritative* is a property of your
+deployment, not of the CRD; see
+[securing ephemeral access](/docs/ephemeral-access-security).
+
+## Request phases
+
+`status.phase` is the single field to read when asking what a request is doing.
+Eleven values, of which six are terminal:
+
+| Phase | Meaning |
+| --- | --- |
+| `Pending` | Created; the operator has not yet resolved the bundle |
+| `PendingApproval` | Resolved, waiting for a decision under `approval.mode: Required` |
+| `Applying` | Approved; membership SQL is being executed |
+| `Active` | Membership granted; `status.expiresAt` holds the absolute deadline |
+| `Revoking` | Expiry or deletion reached; membership is being taken back |
+| `Ended` | Ran to its expiry and was revoked cleanly *(terminal)* |
+| `Revoked` | Revoked before its expiry *(terminal)* |
+| `Cancelled` | Withdrawn before activation began *(terminal)* |
+| `Denied` | A decision maker refused it *(terminal)* |
+| `ApprovalExpired` | No decision within `pendingRequestTTL` *(terminal)* |
+| `Failed` | Activation or revocation failed; see `status.lastError` *(terminal)* |
+
+Alongside the phase, `status` carries `approvalExpiresAt`, `activatedAt`,
+`expiresAt`, `endedAt`, `lastError`, and `retainedMemberships` — the memberships
+deliberately kept at expiry because something else still needs them.
+
+Requests emit their own Kubernetes Events, so `kubectl describe
+ephemeralaccessrequest <name>` shows one request's history directly.
 
 ## Expiry and deletion
 
@@ -164,9 +200,9 @@ fresh duration after restart.
 
 Suspending an access policy blocks new activation while active requests run to
 their existing expiry. Deleting an access policy deletes and revokes its
-requests before the policy finalizer completes. Do not forcibly remove
-finalizers: authoritative reconciliation can later heal a stranded membership,
-but additive mode may leave it indefinitely.
+requests before the policy finalizer completes. Do not force-remove finalizers —
+that is how a membership is left in PostgreSQL with no request remaining to
+revoke it.
 
 Deleting a target `PostgresPolicy` first deletes attached access policies and
 waits for their request finalizers, keeping the database connection available

--- a/docs/src/pages/docs/ephemeral-access.md
+++ b/docs/src/pages/docs/ephemeral-access.md
@@ -21,10 +21,11 @@ The feature does not issue credentials or implement cloud login — the subject
 must already exist as a PostgreSQL role.
 
 {% callout type="warning" title="Requests need a trust boundary before you enable them" %}
-Anyone who can create requests can grant themselves the bundle, and `Required`
-approval is only a real boundary under admission enforcement or a trusted
-broker. Read [securing ephemeral access](/docs/ephemeral-access-security) before
-allowing requests in a cluster that matters.
+Under `approval.mode: Automatic`, anyone who can create a request can grant
+themselves the bundle. Under `Required`, approval is a real boundary only with
+admission enforcement or a trusted broker in front of it. Read
+[securing ephemeral access](/docs/ephemeral-access-security) before allowing
+requests in a cluster that matters.
 {% /callout %}
 
 ## Define a requestable bundle
@@ -162,26 +163,36 @@ deployment, not of the CRD; see
 
 ## Request phases
 
-`status.phase` is the single field to read when asking what a request is doing.
-Eleven values, of which six are terminal:
+`status.phase` is the field to read when asking what a request is doing. These
+are the values you can observe on a live object:
 
 | Phase | Meaning |
 | --- | --- |
 | `Pending` | Created; the operator has not yet resolved the bundle |
 | `PendingApproval` | Resolved, waiting for a decision under `approval.mode: Required` |
-| `Applying` | Approved; membership SQL is being executed |
+| `Applying` | Membership SQL is being executed — after approval, or straight from resolution under `approval.mode: Automatic` |
 | `Active` | Membership granted; `status.expiresAt` holds the absolute deadline |
-| `Revoking` | Expiry or deletion reached; membership is being taken back |
-| `Ended` | Ran to its expiry and was revoked cleanly *(terminal)* |
-| `Revoked` | Revoked before its expiry *(terminal)* |
-| `Cancelled` | Withdrawn before activation began *(terminal)* |
+| `Revoking` | The expiry deadline passed; membership is being taken back |
+| `Ended` | Reached its expiry *(terminal)* |
+| `Cancelled` | The access policy changed or was suspended, or the request expired before activation began *(terminal)* |
 | `Denied` | A decision maker refused it *(terminal)* |
 | `ApprovalExpired` | No decision within `pendingRequestTTL` *(terminal)* |
-| `Failed` | Activation or revocation failed; see `status.lastError` *(terminal)* |
+
+Two further phases exist in the API but will not be seen in `status.phase`.
+`Revoked` describes deletion, and is written to the audit stream and the request's
+Events but deliberately not to an object whose finalizer is about to be removed —
+so deletion never passes through `Revoking` either. `Failed` is defined and
+classified as a warning, but no code path currently sets it: an activation or
+revocation error leaves the phase alone and records `status.lastError` while the
+reconcile retries. Alert on `lastError`, not on `phase: Failed`.
+
+`Ended` does not always mean the memberships were revoked. When a membership has
+become part of the durable `PostgresPolicy` in the meantime it is kept and
+recorded in `status.retainedMemberships`; memberships kept because another active
+request still needs them are left in place without being recorded there.
 
 Alongside the phase, `status` carries `approvalExpiresAt`, `activatedAt`,
-`expiresAt`, `endedAt`, `lastError`, and `retainedMemberships` — the memberships
-deliberately kept at expiry because something else still needs them.
+`expiresAt`, `endedAt`, and `lastError`.
 
 Requests emit their own Kubernetes Events, so `kubectl describe
 ephemeralaccessrequest <name>` shows one request's history directly.
@@ -201,8 +212,9 @@ fresh duration after restart.
 Suspending an access policy blocks new activation while active requests run to
 their existing expiry. Deleting an access policy deletes and revokes its
 requests before the policy finalizer completes. Do not force-remove finalizers —
-that is how a membership is left in PostgreSQL with no request remaining to
-revoke it.
+that strands the membership in PostgreSQL with no request left to revoke it.
+Authoritative reconciliation of the durable policy can later remove the stray
+edge; additive mode may leave it indefinitely.
 
 Deleting a target `PostgresPolicy` first deletes attached access policies and
 waits for their request finalizers, keeping the database connection available

--- a/docs/src/pages/docs/limitations.md
+++ b/docs/src/pages/docs/limitations.md
@@ -38,7 +38,3 @@ PostgreSQL does not expose password hashes for comparison, so pgroles cannot det
 ## Databases themselves
 
 pgroles grants privileges *on* a database (`CONNECT`, `CREATE`, `TEMPORARY`) but does not create, drop, or rename databases, and does not manage database ownership (`ALTER DATABASE ... OWNER TO`). Provision the database itself with your migration tooling or infrastructure-as-code before pointing a pgroles manifest at it.
-
-## Orphaning policies leaks plan resources
-
-Deleting a policy with `--cascade=orphan` leaves its plans and plan-SQL ConfigMaps behind. These resources are matched to their policy by owner UID rather than by name, so they are not re-adopted by a recreated policy of the same name. Because orphan deletion strips the owner references that garbage collection relies on, they persist until deleted by hand. Prefer the default cascading delete; if you have already orphaned some, delete leftover `pgplan` objects and `*-sql` ConfigMaps explicitly.

--- a/docs/src/pages/docs/operator-production-status.md
+++ b/docs/src/pages/docs/operator-production-status.md
@@ -55,9 +55,10 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 **Deployment security:**
 
-- The operator requires cluster-scoped controller RBAC with Secret read access;
-  there is no namespace-scoped deployment option. Ephemeral request and
-  approval hardening is covered in [securing ephemeral access](/docs/ephemeral-access-security).
+- The operator requires controller RBAC with Secret read access. It is
+  cluster-scoped by default; `operator.watchNamespace` scopes every watch and
+  the chart's RBAC to a single namespace. Ephemeral request and approval
+  hardening is covered in [securing ephemeral access](/docs/ephemeral-access-security).
 
 **Deletion semantics:**
 

--- a/docs/src/pages/docs/operator-production-status.md
+++ b/docs/src/pages/docs/operator-production-status.md
@@ -47,7 +47,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 **Password drift visibility:**
 
-- PostgreSQL does not expose password material in a way pgroles can compare safely. The operator can detect password source Secret changes and re-apply them, but it cannot detect out-of-band manual password changes made directly in the database.
+- The operator re-applies passwords when the source Secret changes, but cannot detect a password changed directly in the database. See [password drift](/docs/limitations#password-drift) for why PostgreSQL makes this undetectable.
 
 **Managed provider validation:**
 

--- a/docs/src/pages/docs/operator-production-status.md
+++ b/docs/src/pages/docs/operator-production-status.md
@@ -63,6 +63,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 **Deletion semantics:**
 
 - Deleting a `PostgresPolicy` stops reconciliation but does not revert the database. This is by design (stop managing, not undo) but differs from GitOps conventions where deleting a resource reverts its effects.
+- Deleting a policy with `--cascade=orphan` leaves its plans and plan-SQL ConfigMaps behind. They are matched to their policy by owner UID rather than by name, so a recreated policy of the same name does not re-adopt them, and orphan deletion strips the owner references that garbage collection relies on. Prefer the default cascading delete; if you have already orphaned some, delete the leftover `pgplan` objects and `*-sql` ConfigMaps by hand.
 
 ## Path to API stability
 

--- a/docs/src/pages/docs/operator-quick-start.md
+++ b/docs/src/pages/docs/operator-quick-start.md
@@ -48,8 +48,10 @@ kubectl get pods -n pgroles-system \
   -l app.kubernetes.io/instance=pgroles-operator
 ```
 
-The chart installs the `PostgresPolicy` and `PostgresPolicyPlan` CRDs. The
-operator watches policies in every namespace.
+The chart installs four CRDs: `PostgresPolicy`, `PostgresPolicyPlan`, and the
+`EphemeralAccessPolicy` / `EphemeralAccessRequest` pair behind
+[ephemeral access](/docs/ephemeral-access). The operator watches every namespace
+unless `operator.watchNamespace` scopes it to one.
 
 ## 2. Add the database credential
 

--- a/docs/src/pages/docs/operator-security.md
+++ b/docs/src/pages/docs/operator-security.md
@@ -9,7 +9,10 @@ What the operator is allowed to do in your cluster. {% .lead %}
 
 ## RBAC
 
-The operator requires a ClusterRole with these permissions:
+The operator requires these permissions. They are granted through a
+`ClusterRole` by default, or a namespaced `Role` when
+[`operator.watchNamespace`](/docs/operator-install) scopes the operator to one
+namespace — the rules themselves are identical either way:
 
 | API group | Resource | Verbs |
 | --- | --- | --- |
@@ -34,6 +37,8 @@ hard-coding a service account identity, which is why the operator holds it
 while holding neither `use` nor `approve`. See
 [securing ephemeral access](/docs/ephemeral-access-security).
 
-The Helm chart creates the ClusterRole, ClusterRoleBinding, and ServiceAccount
-automatically. `charts/pgroles-operator/templates/clusterrole.yaml` is the source
-of truth; check it against this table before hand-writing a role.
+The Helm chart creates the role, its binding, and the ServiceAccount
+automatically — a `ClusterRole` and `ClusterRoleBinding` normally, a `Role` and
+`RoleBinding` in the watched namespace when `operator.watchNamespace` is set.
+`charts/pgroles-operator/templates/clusterrole.yaml` is the source of truth for
+the rules; check it against this table before hand-writing a role.

--- a/docs/src/pages/docs/operator-security.md
+++ b/docs/src/pages/docs/operator-security.md
@@ -26,12 +26,12 @@ The operator requires a ClusterRole with these permissions:
 | `""` | `configmaps` | get, list, create, update, patch, delete |
 | `events.k8s.io` | `events` | create, patch |
 
-Every rule is load-bearing. `postgrespolicyplans` is required to apply anything
-at all, because each apply goes through a plan; `configmaps` stores plan SQL
-above the inline size limit. The `manage` verb is a logical permission with no
-built-in meaning: admission policy uses it to authorize operator-owned request
-lifecycle changes without hard-coding a service account identity, which is why
-the operator holds it while holding neither `use` nor `approve`. See
+`postgrespolicyplans` is required to apply anything at all, because each apply
+goes through a plan; `configmaps` stores plan SQL above the inline size limit.
+The `manage` verb is a logical permission with no built-in meaning: admission
+policy uses it to authorize operator-owned request lifecycle changes without
+hard-coding a service account identity, which is why the operator holds it
+while holding neither `use` nor `approve`. See
 [securing ephemeral access](/docs/ephemeral-access-security).
 
 The Helm chart creates the ClusterRole, ClusterRoleBinding, and ServiceAccount

--- a/docs/src/pages/docs/operator-status.md
+++ b/docs/src/pages/docs/operator-status.md
@@ -115,7 +115,7 @@ The intended deployment model is operator -> OpenTelemetry Collector -> your met
 | `pgroles.wildcard.grantability_queries` | - | Wildcard grantability catalog queries issued |
 | `pgroles.wildcard.unsatisfied_grants` | - | Wildcard grants missing privileges before grantability checks |
 | `pgroles.ephemeral_access.transitions` | `phase`, `reason` | Ephemeral request phase transitions |
-| `pgroles.ephemeral_access.failures` | `reason` | Ephemeral activation and revocation failures |
+| `pgroles.ephemeral_access.failures` | `reason` | Requests reaching a failed terminal phase — in practice `Denied` and `ApprovalExpired`, since nothing sets `Failed` |
 | `pgroles.ephemeral_access.retained_memberships` | - | Memberships kept at expiry because they became durable |
 | `pgroles.ephemeral_access.expiry_lag` | - | Milliseconds between expiry and revocation |
 | `pgroles.ephemeral_access.role_retirement_blocked` | - | Role retirements blocked by an in-flight request |
@@ -158,8 +158,8 @@ Ephemeral access requests carry their own Events, recorded on the
 `EphemeralAccessRequest` object rather than on the policy, with the action
 `EphemeralAccessLifecycle`. Terminal failures — `Failed`, `Denied`, and
 `ApprovalExpired` — are `Warning`; every other phase transition is `Normal`. So
-`kubectl describe ephemeralaccessrequest <name>` is where one request's history
-lives, not `kubectl describe pgr`.
+`kubectl describe -n <namespace> ephemeralaccessrequest <name>` is where one
+request's history lives, not `kubectl describe pgr`.
 
 Not every failure becomes an Event. `MissingDatabaseObject`,
 `InvalidConnectionParams`, and `UnsatisfiableWildcardGrant` are condition

--- a/docs/src/pages/docs/operator-status.md
+++ b/docs/src/pages/docs/operator-status.md
@@ -124,12 +124,15 @@ The intended deployment model is operator -> OpenTelemetry Collector -> your met
 | `pgroles.ephemeral_access.reconcile.duration` | `kind`, `request_count` | Ephemeral reconcile wall time, bucketed by request count |
 | `pgroles.ephemeral_access.reconcile.inflight` | `kind` | Ephemeral reconciles currently running |
 
-Useful alerting signals: `Degraded=True` for reconcile failure (not bare
-`Ready=False`, which is also how a healthy plan-awaiting-approval policy
-reports), sustained `Drifted=True` on an auto-applying policy,
-`pgroles.lock_contention.total` rising steadily, and
-`pgroles.deprecated.approval_unset` as the count of policies still relying on
-the deprecated inference.
+Useful alerting signals: `Degraded=True` for reconcile failure, sustained
+`Drifted=True` on an auto-applying policy, `pgroles.lock_contention.total`
+rising steadily, and `pgroles.deprecated.approval_unset` as the count of
+policies still relying on the deprecated inference.
+
+A policy waiting on plan approval is healthy and reports `Ready=True` with
+reason `Planned`, alongside `Drifted=True`. `Drifted` is what distinguishes it
+from a policy with nothing to do; `Ready=False` always means something is
+wrong.
 
 The operator also emits transition-based Kubernetes Events on the policy.
 Status transitions:

--- a/docs/src/pages/docs/operator-status.md
+++ b/docs/src/pages/docs/operator-status.md
@@ -121,7 +121,7 @@ The intended deployment model is operator -> OpenTelemetry Collector -> your met
 | `pgroles.ephemeral_access.role_retirement_blocked` | - | Role retirements blocked by an in-flight request |
 | `pgroles.ephemeral_access.cached_requests` | - | Request-cache size sampled at reconcile start |
 | `pgroles.ephemeral_access.relevant_requests` | `lookup` | Requests returned by an indexed lookup |
-| `pgroles.ephemeral_access.reconcile.duration` | `kind`, request-count bucket | Ephemeral reconcile wall time |
+| `pgroles.ephemeral_access.reconcile.duration` | `kind`, `request_count` | Ephemeral reconcile wall time, bucketed by request count |
 | `pgroles.ephemeral_access.reconcile.inflight` | `kind` | Ephemeral reconciles currently running |
 
 Useful alerting signals: `Degraded=True` for reconcile failure (not bare

--- a/docs/src/pages/docs/operator-status.md
+++ b/docs/src/pages/docs/operator-status.md
@@ -119,6 +119,10 @@ The intended deployment model is operator -> OpenTelemetry Collector -> your met
 | `pgroles.ephemeral_access.retained_memberships` | - | Memberships kept at expiry because they became durable |
 | `pgroles.ephemeral_access.expiry_lag` | - | Milliseconds between expiry and revocation |
 | `pgroles.ephemeral_access.role_retirement_blocked` | - | Role retirements blocked by an in-flight request |
+| `pgroles.ephemeral_access.cached_requests` | - | Request-cache size sampled at reconcile start |
+| `pgroles.ephemeral_access.relevant_requests` | `lookup` | Requests returned by an indexed lookup |
+| `pgroles.ephemeral_access.reconcile.duration` | `kind`, request-count bucket | Ephemeral reconcile wall time |
+| `pgroles.ephemeral_access.reconcile.inflight` | `kind` | Ephemeral reconciles currently running |
 
 Useful alerting signals: `Degraded=True` for reconcile failure (not bare
 `Ready=False`, which is also how a healthy plan-awaiting-approval policy
@@ -146,6 +150,13 @@ Plan lifecycle:
 
 - `PlanCreated`, `PlanApproved`, `PlanRejected`
 - `ApplyStarted`, `ApplySucceeded`, `ApplyFailed`
+
+Ephemeral access requests carry their own Events, recorded on the
+`EphemeralAccessRequest` object rather than on the policy, with the action
+`EphemeralAccessLifecycle`. Terminal failures — `Failed`, `Denied`, and
+`ApprovalExpired` — are `Warning`; every other phase transition is `Normal`. So
+`kubectl describe ephemeralaccessrequest <name>` is where one request's history
+lives, not `kubectl describe pgr`.
 
 Not every failure becomes an Event. `MissingDatabaseObject`,
 `InvalidConnectionParams`, and `UnsatisfiableWildcardGrant` are condition

--- a/docs/src/pages/docs/quick-start.md
+++ b/docs/src/pages/docs/quick-start.md
@@ -35,8 +35,6 @@ Before typing any YAML, here is the role graph the manifest below describes — 
 Create a file called `pgroles.yaml`:
 
 ```yaml
-default_owner: app_owner
-
 roles:
   - name: analytics
     login: true

--- a/docs/src/pages/docs/quick-start.md
+++ b/docs/src/pages/docs/quick-start.md
@@ -1,5 +1,5 @@
 ---
-title: Quick start
+title: CLI quick start
 description: Install pgroles and run your first manifest against a PostgreSQL database.
 ---
 
@@ -27,6 +27,10 @@ Use `pgroles generate --database-url ... > pgroles.yaml` first, then refine the 
 {% /callout %}
 
 ## Create a manifest
+
+Before typing any YAML, here is the role graph the manifest below describes — a single login role with read-only access to one schema.
+
+{% role-graph-diagram /%}
 
 Create a file called `pgroles.yaml`:
 

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -28,7 +28,7 @@ Built for platform teams, DBAs, and anyone managing more than a handful of Postg
 
 {% quick-links %}
 
-{% quick-link title="Quick start" icon="installation" href="/docs/quick-start" description="Install pgroles and run your first diff against a live database." /%}
+{% quick-link title="CLI quick start" icon="installation" href="/docs/quick-start" description="Install pgroles and run your first diff against a live database." /%}
 
 {% quick-link title="Manifest guide" icon="presets" href="/docs/manifest-format" description="Learn how manifest sections fit together when designing a policy." /%}
 


### PR DESCRIPTION
A documentation pass over the docs site and `AGENTS.md`, prompted by reading the ephemeral access pages and finding they had not kept up with the feature.

No source changes. Every behavioural claim below was checked against the Rust source, and the site builds clean at each commit.

## Stale claims

**Ephemeral access did not require PostgreSQL 16**, as `ephemeral-access.md` stated. `validate_membership_semantics` (`ephemeral.rs:1946`) returns early on PG16+, and on older servers rejects a membership only when its `inherit` differs from the subject role's global `INHERIT` — which is why the test is named `postgres_15_accepts_matching_global_inherit_and_pg16_accepts_either`. The page now describes the real constraint.

**The `AGENTS.md` CRD recipe predated the ephemeral kinds.** It claimed four committed copies and gave two `cp` lines; `crdgen` emits four CRDs and `check-crd-drift.sh` compares eight. An agent following that recipe failed the gate. Both missing `cp` lines added.

**The CI section counted five jobs against ten** and never mentioned the ephemeral E2E. It no longer counts jobs.

**`operator-quick-start.md` said the chart installs two CRDs.** It installs four.

**`operator-production-status.md` said there is no namespace-scoped deployment option**, and `operator-security.md` said the operator requires a `ClusterRole` and that the chart always creates one. `operator.watchNamespace` has been exactly that option since #165, and the chart templates switch to a namespaced `Role`/`RoleBinding` when it is set.

**The alerting guidance said a healthy plan-awaiting-approval policy reports `Ready=False`**, and told operators not to alert on it. The reconciler sets `ready_condition(true, "Planned", ..)` alongside `Drifted=True` — the condition table two sections earlier already said so. The advice would have taught operators to ignore a genuinely unhealthy `Ready=False`.

## Diagrams that missed the overlay

The `AGENTS.md` Data Pipeline block ended at `RoleGraph (desired)` and diffed against it. `compose_effective_graph` runs at `reconciler.rs:961`, before the database inspect, so in the operator the graph being diffed is not the one the manifest expanded to.

The operator control-plane diagram had no ephemeral content at all, and was missing `PostgresPolicyPlan` approval changes that the surrounding prose has always listed as a trigger source.

I initially also listed `EphemeralAccessRequest` lifecycle changes as a trigger for that pipeline. That was wrong and is reverted in 568b0ed: `policy_controller` wires only `secret_triggers` and `plan_triggers` (`main.rs:221`), and requests are handled by their own controller.

That distinction turned out to matter for the prose too. The page had said the overlay is what makes an ephemeral membership real. It is not: the request controller executes the grant itself (`apply_scoped_memberships` with `ScopedPlanOperation::Activate`), under the same per-database locks. The overlay does something different — it composes active memberships onto the policy's desired graph so authoritative reconciliation treats them as intended state rather than revoking them as drift. Both mechanisms are now described separately.

## Duplication between the two ephemeral pages

`requestedBy` derivation, `decidedBy` provenance, and the "`use` does not map caller to subject" caveat were each stated in full on both pages. The security page owns the enforcement contract, so the feature page now states the fact and points there. Finalizer stranding was near-verbatim in both; the feature page keeps the operational instruction, the security page keeps the residual-risk framing.

## Missing vocabulary, and two phases that do not behave as named

`ephemeral-access.md` referenced `Applying`, `Pending`, and `ApprovalExpired` without ever defining them, and there was no owner for request status — `operator-status.md` covers `PostgresPolicy` only.

The phase table went through two review passes, both of which found it wrong. What survived is worth reading, because the API is more surprising than it looks:

- **`Failed` is never set.** It exists in the enum, is matched as terminal, and is classified as a `Warning` by the event publisher, but no code path assigns it.
- **`Revoked` is never persisted.** It is set on a clone used for the audit stream and Events; `ephemeral.rs:1341` says it is deliberately not written to an object whose finalizer is about to be removed. Deletion therefore never passes through `Revoking` either — that is entered only when an expiry deadline passes.
- **`Cancelled`** is not requester withdrawal: it comes from the access policy changing or being suspended, or expiry before activation, and the first can fire from `Applying` after membership SQL has run.
- **`Ended` does not imply revocation** — a membership that became durable is kept and recorded in `retainedMemberships`.

That leaves failure genuinely awkward to observe, which the page now states plainly. Only resolution and validation errors write `status.lastError`; an activation or revocation error passes through `access_request_error_policy`, which logs and requeues without touching the phase or `lastError`, while the scoped `PostgresPolicyPlan` records it. And `pgroles.ephemeral_access.failures` — documented as counting activation and revocation failures — only increments for the `Failed`, `Denied`, and `ApprovalExpired` phases, so with `Failed` unreachable it counts decisions and never SQL failures. The signal for a failed activation is a request that stops advancing in `Applying` or `Revoking`.

`operator-status.md` also gains the four ephemeral metrics it was missing and a note that request Events land on the `EphemeralAccessRequest` with action `EphemeralAccessLifecycle`, not on the policy.

## Orientation and structure

`ephemeral-access.md` led with a trust-model warning before saying what the feature is. It now explains the three resources and the two mechanisms first, then warns — and the warning is qualified, since unrestricted self-service holds under `Automatic` approval rather than unconditionally.

The CLI quick start opens with a diagram of the role graph it builds. The tutorial's manifest has no memberships, so the diagram says that plainly and pins the `member -> role` direction for later rather than inventing structure. `default_owner: app_owner` is gone from that first manifest — it is optional, the tutorial never used it, and the diagram was spending half its notes explaining that a line does nothing.

Both quick starts now appear in Introduction, since CLI-versus-operator is the first choice a reader makes and the operator path was item 2 of a 14-item section. "Operator quick start" deliberately remains in the operator section too. Related tools moved to Reference; Application access patterns moved from CLI to Writing policy, having nothing CLI-specific in it. Orphaned plan resources moved from Limitations to the operator's Known gaps.

## Follow-ups, not in this PR

- **`EphemeralAccessRequestPhase::Failed` is dead API surface** in a `v1alpha1` CRD. Either wire it up for terminal activation failures or drop it before the API stabilises.
- **`pgroles.ephemeral_access.failures` cannot observe what its name suggests**, for the same reason. Worth revisiting alongside the phase.
- **An E2E case for force-removing an active request's finalizer.** The suite covers admission rejecting such a removal, but not the consequence when one gets through.
- **The `[0.9.0]` changelog carries the same PG16 overstatement.** Left alone as a shipped entry.
- **The 0.8.0 changelog links to `/docs/limitations`** for orphaned plan resources, which now live on the production-status page.

## Verification

- `cd docs && npm run build` — exit 0 at each commit; every page prerenders
- Every behavioural claim checked against `crates/pgroles-operator/src/` and the workflow and script files described
- All internal links and sidebar hrefs resolve; no page left unreachable
- Each passage removed as duplicated was confirmed to survive on the security page

https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a visual role-graph example showing database privileges and role relationships.
  - Clarified CLI and operator quick-start paths, application access patterns, and related tools.
  - Expanded ephemeral access guidance, including lifecycle states, security boundaries, validation, cleanup, metrics, and events.
  - Documented namespace-scoped deployments, RBAC behavior, CRD installation, and production limitations.
  - Updated architecture and CI documentation with ephemeral access workflows and expanded validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->