### PR TITLE
docs: end-state documentation for candidate planning and hardened approval (#173)

### DIFF
--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -29,6 +29,7 @@ const navigation = [
             {title: 'The PostgresPolicy resource', href: '/docs/operator-postgrespolicy'},
             {title: 'Database connections', href: '/docs/operator-connections'},
             {title: 'Plan and approval', href: '/docs/operator-plan-approval'},
+            {title: 'Candidates and promotion', href: '/docs/operator-candidates'},
             {title: 'Running the operator', href: '/docs/operator-operations'},
             {title: 'Status and telemetry', href: '/docs/operator-status'},
             {title: 'Troubleshooting index', href: '/docs/operator-troubleshooting'},

--- a/docs/src/pages/docs/operator-candidates.md
+++ b/docs/src/pages/docs/operator-candidates.md
@@ -1,0 +1,231 @@
+---
+title: Candidates and promotion
+description: Propose policy changes, review their exact PostgreSQL effects, and promote them — while the active policy stays enforced.
+---
+
+Review what a change would do to production before it becomes the desired state. {% .lead %}
+
+---
+
+{% callout type="warning" title="Design preview" %}
+This page documents the target design from
+[#173](https://github.com/hardbyte/pgroles/issues/173) ahead of implementation.
+It is written as end-state documentation so the design can be reviewed in the
+form users will meet it. Nothing on this page is released yet.
+{% /callout %}
+
+## What a candidate is
+
+A `PostgresPolicyCandidate` is a one-shot, immutable proposal: policy content
+that an author wants reviewed against a live database without touching the
+`PostgresPolicy` that is enforcing it. The operator plans the candidate in the
+active policy's own execution context — same credentials, same advisory lock,
+same managed scope — and publishes a `PostgresPolicyPlan` describing exactly
+what would change. The active policy keeps enforcing throughout.
+
+A candidate is not a second policy. It carries no connection, interval, or
+mode; it can never execute SQL in any state; and it is terminal once promoted,
+superseded, or stale. Think of it the way you think of a
+`CertificateSigningRequest`: a request for the controller to produce a
+reviewable result, not a piece of desired state.
+
+The kinds divide authority. Anyone granted create on candidates can propose;
+only whoever can write `PostgresPolicy` (typically your GitOps controller) can
+promote; only plan approvers can approve. None of those grants implies the
+others.
+
+## Who does what
+
+The intended workflow, end to end:
+
+1. An author (or CI, from a PR branch) files a candidate against the cluster.
+2. The operator plans it and publishes the redacted effects.
+3. A reviewer approves or rejects the **plan** — this is the single
+   operator-checked approval.
+4. The pull request merges, promoting the same content into
+   `PostgresPolicy.spec`. The merge is *promotion*, not a second approval:
+   `pgroles candidate verify` runs in CI to confirm the PR content digest
+   matches the approved candidate before merge.
+5. The operator executes only when the promoted content digest matches the
+   approved candidate and the recomputed effects match the approved change
+   digest, verified under the database lock.
+
+Candidates are imperative, CI- or CLI-created objects. They are deliberately
+not GitOps-managed: `generateName` does not work with Argo CD or Flux tracking,
+and a proposal has no business being continuously re-applied.
+
+## Creating a candidate
+
+```yaml
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicyCandidate
+metadata:
+  generateName: orders-change-
+spec:
+  policyRef:
+    name: orders
+  content:
+    reconciliation_mode: authoritative
+    roles:
+      - name: reporting-reader
+        login: true
+    grants: []
+    default_privileges: []
+    memberships: []
+    retirements: []
+```
+
+`spec.content` is the exact policy-content schema from `PostgresPolicySpec` —
+everything except connection, interval, mode, and approval, which always come
+from the parent policy. The whole spec is immutable (`self == oldSelf`); to
+revise a proposal, create a successor:
+
+```bash
+pgroles candidate create --policy orders -f revised.yaml --replaces orders-change-x7k2p
+```
+
+`spec.replaces` marks the named earlier draft superseded. Supersession is
+always explicit — the operator never infers it from creator identity, because
+CI typically files every team's candidates under one service account.
+
+There is no base pin in the spec. The plan records which applied base it was
+computed against; staleness is decided semantically from there (see
+[Staleness](#staleness-and-revalidation)).
+
+## What the operator does with it
+
+A new candidate enqueues its parent policy. Inside one lock hold, the
+operator:
+
+1. reconciles the active policy first, so the candidate is planned against
+   post-enforcement reality rather than drift
+2. plans the candidate content against that state
+3. publishes an operator-owned `PostgresPolicyPlan` bound to the candidate
+   (name and UID), its content digest, the applied-base digest it observed,
+   the target identity, the managed scope, and the canonical change digest
+
+Planning writes nothing: no PostgreSQL statements, no generated password
+Secrets, no changes to the active policy. Filing a candidate may advance the
+parent's scheduled convergence — the reconcile it triggers is the same one the
+interval would have run — but no effect of the candidate itself executes.
+
+If the active policy is failing or awaiting its own approval, the candidate
+reports `Ready=False` with reason `BlockedByActivePolicy` and is re-planned
+when the parent recovers.
+
+```text
+NAME                  POLICY   PHASE     CHANGES   PLAN                              AGE
+orders-change-x7k2p   orders   Planned   3         orders-change-x7k2p-plan-9f21c4   14s
+```
+
+## Reviewing and deciding
+
+The candidate's plan is reviewed and decided exactly like any other
+`PostgresPolicyPlan` — same redacted SQL preview, same change summary, same
+write-once decision recorded on the plan status with an admission-stamped
+`decidedBy`. See [Plan and approval](/docs/operator-plan-approval) for the
+decision mechanics and their trust model.
+
+```bash
+pgroles candidate show orders-change-x7k2p     # plan summary, effects, digests
+pgroles plan approve orders-change-x7k2p-plan-9f21c4
+```
+
+## Promotion
+
+Approval does not change the `PostgresPolicy`. Promotion is the ordinary
+GitOps write: the PR carrying the same content merges, the GitOps controller
+updates `PostgresPolicy.spec`, and the operator recognises the update as the
+approved candidate by digest.
+
+Run `pgroles candidate verify` in CI before merge:
+
+```bash
+pgroles candidate verify orders-change-x7k2p --against path/to/policy.yaml
+```
+
+It fails when the PR's rendered content digest differs from the candidate's —
+catching edited-after-approval content *before* the merge, when it is cheap,
+instead of at promotion, when the spec has already changed.
+
+The edge cases are defined, not implied:
+
+| What happens | Result |
+| --- | --- |
+| Promoted content matches the approved candidate, base unchanged | Executes under the lock after fresh verification |
+| Promoted content was edited after approval (digest mismatch) | Nothing executes; the policy falls back to the normal manual-plan flow with an explicit condition |
+| Promotion with no approved plan at all | Normal manual-plan flow |
+| Plan X approved, candidate Y merged | Y plans fresh; X goes stale |
+
+One honest cost to know: after a mismatched promotion, the merged spec is the
+desired state but is unenforced until a fresh plan is approved — the same
+suspension `apply + manual` has always had, surfaced by condition and Event
+and bounded by the plan retention TTL. Continued enforcement of the *previous*
+state through a failed promotion is what a future Revision model would add.
+
+## Staleness and revalidation
+
+Staleness is semantic. When anything the plan depends on changes — the applied
+base, the live database, active ephemeral overlays — the operator replans the
+candidate and compares canonical change digests:
+
+- **identical digest**: the plan and any decision on it are retained; the
+  revalidation is recorded. Unrelated base changes and unrelated ephemeral
+  activity do not cost you a review round.
+- **changed digest**: the plan is superseded with an explicit condition and
+  Event, and the fresh plan awaits a fresh decision.
+
+An ephemeral overlay that overlaps the candidate's effects supersedes the plan
+with reason `OverlayOverlap`. One that does not leaves the digest identical
+and the plan stands — candidates remain usable on policies with active
+ephemeral traffic.
+
+After a successful promotion, other candidates against the same policy are
+replanned against the new base by the same rule.
+
+## Previewing a connection migration
+
+A candidate may target a different connection than its parent policy, to
+inspect what convergence would do on a migration destination before the
+active policy follows it:
+
+```yaml
+spec:
+  policyRef:
+    name: orders
+  target:
+    connectionRef:
+      secretName: orders-new-postgres
+      key: url
+  content: ...
+```
+
+The resulting plan binds the override's target identity; it can never be
+promoted onto the current target by accident, because the digest match fails.
+
+## Retention
+
+Candidates carry an `ownerReference` to their parent policy, and each derived
+plan is owned by its candidate, so pruning cascades. Terminal candidates
+(promoted, superseded, stale, rejected) are pruned by the same bounded
+retention loop as plans; label a candidate `pgroles.io/keep=true` to exempt
+it. Plans also expire after a TTL — an approval is not an indefinite
+authorisation.
+
+## Conditions
+
+`status.phase` is a printable summary; conditions are the source of truth.
+
+| Condition | Meaning |
+| --- | --- |
+| `Ready=True, reason=Planned` | A current plan exists for this candidate |
+| `Ready=False, reason=BlockedByActivePolicy` | Parent is failing or awaiting its own approval; will re-plan |
+| `Ready=False, reason=OverlayOverlap` | An ephemeral grant overlaps this candidate's effects; fresh review required |
+| `Superseded=True` | Replaced by a successor candidate or invalidated by a digest change |
+| `Promoted=True` | This candidate's content was promoted and executed |
+
+## Limits
+
+`spec.content` collections carry explicit size bounds (required by the
+whole-spec immutability rule's CEL cost budget). Policies too large to embed
+can pass content by reference; the digest binding is identical either way.

--- a/docs/src/pages/docs/operator-candidates.md
+++ b/docs/src/pages/docs/operator-candidates.md
@@ -1,6 +1,6 @@
 ---
 title: Candidates and promotion
-description: Propose policy changes, review their exact PostgreSQL effects, and promote them — while the active policy stays enforced.
+description: Propose policy changes, review their exact PostgreSQL effects, and promote them — while the active policy keeps enforcing during review.
 ---
 
 Review what a change would do to production before it becomes the desired state. {% .lead %}
@@ -21,11 +21,14 @@ that an author wants reviewed against a live database without touching the
 `PostgresPolicy` that is enforcing it. The operator plans the candidate in the
 active policy's own execution context — same credentials, same advisory lock,
 same managed scope — and publishes a `PostgresPolicyPlan` describing exactly
-what would change. The active policy keeps enforcing throughout.
+what would change. The active policy keeps enforcing throughout review. (After
+promotion the picture changes if the promotion does not match its approval —
+see [Promotion](#promotion).)
 
-A candidate is not a second policy. It carries no connection, interval, or
-mode; it can never execute SQL in any state; and it is terminal once promoted,
-superseded, or stale. Think of it the way you think of a
+A candidate is not a second policy. It carries no interval or mode, and no
+connection unless it is explicitly previewing a different target; it can never
+execute SQL in any state; and it is terminal once promoted, superseded, stale,
+or its plan is rejected. Think of it the way you think of a
 `CertificateSigningRequest`: a request for the controller to produce a
 reviewable result, not a piece of desired state.
 
@@ -76,9 +79,11 @@ spec:
 ```
 
 `spec.content` is the exact policy-content schema from `PostgresPolicySpec` —
-everything except connection, interval, mode, and approval, which always come
-from the parent policy. The whole spec is immutable (`self == oldSelf`); to
-revise a proposal, create a successor:
+everything except connection, interval, mode, and approval. Interval, mode and
+approval always come from the parent policy; the connection does too, unless
+`spec.target` overrides it (see [Previewing a connection
+migration](#previewing-a-connection-migration)). The whole spec is immutable
+(`self == oldSelf`); to revise a proposal, create a successor:
 
 ```bash
 pgroles candidate create --policy orders -f revised.yaml --replaces orders-change-x7k2p
@@ -101,8 +106,9 @@ operator:
    post-enforcement reality rather than drift
 2. plans the candidate content against that state
 3. publishes an operator-owned `PostgresPolicyPlan` bound to the candidate
-   (name and UID), its content digest, the applied-base digest it observed,
-   the target identity, the managed scope, and the canonical change digest
+   (name and UID), its content digest, the target identity, the managed
+   scope, and the canonical change digest — and records the applied base it
+   observed as provenance (see [Staleness](#staleness-and-revalidation))
 
 Planning writes nothing: no PostgreSQL statements, no generated password
 Secrets, no changes to the active policy. Filing a candidate may advance the
@@ -131,6 +137,11 @@ pgroles candidate show orders-change-x7k2p     # plan summary, effects, digests
 pgroles plan approve orders-change-x7k2p-plan-9f21c4
 ```
 
+Rejection lands on the plan, not the candidate: the plan records
+`Denied=True` (phase `Rejected`) and is terminal. The candidate is terminal
+too — it has no other plan coming — and reports `Superseded=True` with reason
+`PlanDenied`. To propose a revised version, file a successor candidate.
+
 ## Promotion
 
 Approval does not change the `PostgresPolicy`. Promotion is the ordinary
@@ -157,21 +168,28 @@ The edge cases are defined, not implied:
 | Promotion with no approved plan at all | Normal manual-plan flow |
 | Plan X approved, candidate Y merged | Y plans fresh; X goes stale |
 
-One honest cost to know: after a mismatched promotion, the merged spec is the
-desired state but is unenforced until a fresh plan is approved — the same
-suspension `apply + manual` has always had, surfaced by condition and Event
-and bounded by the plan retention TTL. Continued enforcement of the *previous*
-state through a failed promotion is what a future Revision model would add.
+One honest cost to know: after a mismatched promotion, nothing has executed
+and the database is unchanged — but the merged spec is now the desired state
+and is not being converged, so drift against *either* state goes unreconciled
+until a fresh plan is approved. That is the same suspension `apply + manual`
+has always had, surfaced by condition and Event and bounded by the plan
+retention TTL. Continued enforcement of the *previous* state through a failed
+promotion is what a future Revision model would add.
 
 ## Staleness and revalidation
 
-Staleness is semantic. When anything the plan depends on changes — the applied
-base, the live database, active ephemeral overlays — the operator replans the
-candidate and compares canonical change digests:
+Staleness is semantic, and the applied base is *provenance, not identity*. The
+plan records which base it was computed against so you can see what it was
+compared to, but that value is not hashed into the change digest — if it were,
+every unrelated base edit would invalidate every open candidate. When anything
+the plan depends on changes — the applied base, the live database, active
+ephemeral overlays — the operator replans the candidate and compares canonical
+change digests:
 
 - **identical digest**: the plan and any decision on it are retained; the
-  revalidation is recorded. Unrelated base changes and unrelated ephemeral
-  activity do not cost you a review round.
+  recorded base advances to the one just observed and the revalidation is
+  noted. Unrelated base changes and unrelated ephemeral activity do not cost
+  you a review round.
 - **changed digest**: the plan is superseded with an explicit condition and
   Event, and the fresh plan awaits a fresh decision.
 
@@ -200,17 +218,36 @@ spec:
   content: ...
 ```
 
-The resulting plan binds the override's target identity; it can never be
-promoted onto the current target by accident, because the digest match fails.
+A target override changes the execution context, and the contract is
+explicit about it:
+
+- **Credentials and connection settings come from the override**, not the
+  parent. The referenced Secret must carry credentials for the destination.
+- **Locking follows the target.** Advisory and in-process locks are keyed by
+  database identity, so planning against the override acquires that
+  database's locks — it cannot share the parent's lock state, and it does not
+  block the parent's reconcile. The enforce-then-plan ordering still applies
+  to the parent (it is reconciled first on its own target); the override is
+  then inspected separately within the same reconcile.
+- **The plan binds the override's target identity**, so it can never be
+  promoted onto the current target by accident: the identity check fails
+  before execution.
+
+Because of that last point, a target-override plan is a *preview*, not a
+migration step. Promoting a migration is a deliberate two-part sequence:
+merge the connection change into `PostgresPolicy.spec` so the active policy
+points at the destination, then approve a plan computed against the new
+target. The override lets you see the destination's diff before committing to
+step one; it never performs the cutover itself.
 
 ## Retention
 
 Candidates carry an `ownerReference` to their parent policy, and each derived
-plan is owned by its candidate, so pruning cascades. Terminal candidates
-(promoted, superseded, stale, rejected) are pruned by the same bounded
-retention loop as plans; label a candidate `pgroles.io/keep=true` to exempt
-it. Plans also expire after a TTL — an approval is not an indefinite
-authorisation.
+plan is owned by its candidate, so pruning cascades. Terminal candidates —
+`Promoted=True`, or `Superseded=True` for any reason including `PlanDenied` —
+are pruned by the same bounded retention loop as plans; label a candidate
+`pgroles.io/keep=true` to exempt it. Plans also expire after a TTL — an
+approval is not an indefinite authorisation.
 
 ## Conditions
 
@@ -221,8 +258,14 @@ authorisation.
 | `Ready=True, reason=Planned` | A current plan exists for this candidate |
 | `Ready=False, reason=BlockedByActivePolicy` | Parent is failing or awaiting its own approval; will re-plan |
 | `Ready=False, reason=OverlayOverlap` | An ephemeral grant overlaps this candidate's effects; fresh review required |
-| `Superseded=True` | Replaced by a successor candidate or invalidated by a digest change |
+| `Superseded=True, reason=Replaced` | A successor candidate named this one in `spec.replaces` |
+| `Superseded=True, reason=EffectsChanged` | Replanning produced a different change digest; the fresh plan awaits its own decision |
+| `Superseded=True, reason=PlanDenied` | The candidate's plan was rejected (terminal) |
 | `Promoted=True` | This candidate's content was promoted and executed |
+
+Rejection is recorded on the plan (`Denied=True`, phase `Rejected`); the
+candidate reflects it as `Superseded=True, reason=PlanDenied`. Both are
+terminal.
 
 ## Limits
 

--- a/docs/src/pages/docs/operator-plan-approval.md
+++ b/docs/src/pages/docs/operator-plan-approval.md
@@ -1,120 +1,69 @@
 ---
 title: Plan and approval
-description: Preview changes with plan mode and gate execution behind a reviewed, approved plan.
+description: Preview changes with observe mode and gate execution behind a reviewed, approved plan.
 ---
 
 Seeing what the operator would do before it does it. {% .lead %}
 
 ---
 
-## Plan mode
+{% callout type="warning" title="Design preview" %}
+This page documents the target design from
+[#173](https://github.com/hardbyte/pgroles/issues/173) ahead of implementation:
+`mode: observe` (renamed from `plan`), the semantic change digest, write-once
+plan decisions, and tiered target identity. Released behaviour still uses
+`mode: plan`, approval annotations, and SQL-hash matching.
+{% /callout %}
 
-Set `mode: plan` to let the operator inspect the database, compute the diff, and publish the planned SQL without executing it.
+## Observe mode
+
+Set `mode: observe` to let the operator inspect the database, compute the
+diff, and publish the planned SQL without executing it. (`observe` is the mode
+previously named `plan` — renamed so that "plan" means exactly one thing: the
+`PostgresPolicyPlan` resource.)
 
 ```yaml
 spec:
   connection:
     secretRef:
       name: postgres-credentials
-  mode: plan
+  mode: observe
   approval: manual
   roles:
     - name: preview-user
       login: true
 ```
 
-Plan mode is useful when you want the operator to stay in-cluster but you are not ready to trust it with PostgreSQL mutations yet.
-
-In `plan` mode:
+In `observe` mode:
 
 - the operator connects to the database and computes the full diff normally
-- no mutating PostgreSQL SQL is executed
+- no mutating PostgreSQL SQL is executed and no Kubernetes Secrets are created
 - `status.change_summary` records the pending changes
-- `status.current_plan_ref.name` points at the generated `PostgresPolicyPlan`, which holds the rendered SQL in `status.sqlInline` or, for larger plans, a gzipped ConfigMap referenced by `status.sqlRef`
-- `Ready=True` with reason `Planned`
-- `Drifted=True` when changes are pending, `Drifted=False` when the database is already in sync
-- for `password.generate`, the controller does not create or recreate the generated Kubernetes Secret while running in `plan` mode
-- for password-managed roles, `Drifted=False` is only possible after a prior successful `apply` recorded the password source version; a plan-only policy cannot prove an existing database password already matches the configured source
+- `status.current_plan_ref.name` points at the generated `PostgresPolicyPlan`,
+  which holds the rendered SQL in `status.sqlInline` or, for larger plans, a
+  gzipped ConfigMap referenced by `status.sqlRef`
+- `Ready=True` with reason `Planned`; `Drifted=True` while changes are pending
 
-Example `kubectl get` output:
+Be clear about what `observe` is not: it is a mutable spec field, not a
+security boundary. Anyone who can edit the policy can switch it to `apply`,
+and the operator still holds whatever database credential it was given. For
+deployments where the operator must never write, the guarantee is a
+**read-only PostgreSQL credential** — `observe` is what makes running under
+one coherent (drift visibility without a stream of permission-denied errors).
+For a reviewed apply, use `mode: apply` with `approval: manual`. Use `suspend`
+to stop reconciling entirely.
 
-```text
-NAME          READY   MODE   DRIFT   CHANGES   LAST RECONCILE   AGE
-plan-policy   True    plan   True    2         2s               2s
-```
-
-Example status fields:
-
-```yaml
-status:
-  change_summary:
-    grants_added: 1
-    roles_created: 1
-    total: 2
-  conditions:
-    - type: Ready
-      status: "True"
-      reason: Planned
-      message: Plan computed; 2 change(s) pending
-    - type: Drifted
-      status: "True"
-      reason: DriftDetected
-      message: 2 planned change(s) pending review
-  current_plan_ref:
-    name: plan-policy-plan-20260512-090308-118e50e437c9
-  last_reconcile_mode: plan
-```
-
-The rendered SQL lives on the plan, so start from the policy name you already
-have and follow `current_plan_ref` to it:
+The rendered SQL lives on the plan; follow `current_plan_ref` to it:
 
 ```bash
-POLICY=plan-policy
+POLICY=observed-policy
 PLAN="$(kubectl get pgr "$POLICY" -o jsonpath='{.status.current_plan_ref.name}')"
 kubectl get pgplan "$PLAN" -o jsonpath='{.status.sqlInline}'
 ```
 
-```text
-CREATE ROLE "plan-preview-user" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
-COMMENT ON ROLE "plan-preview-user" IS 'Preview-only role';
-GRANT CONNECT ON DATABASE "postgres" TO "plan-preview-user";
-```
-
-To see every plan a policy has produced rather than just the current one, list
-plans and read the `POLICY` column, which carries the full policy name:
-
-```bash
-kubectl get pgplan
-```
-
-```text
-NAME                                                     POLICY        MODE            APPROVED   CHANGES   PHASE     AGE
-plan-policy-plan-20260512-090308-118e50e437c9            plan-policy   authoritative   False      2         Pending   3s
-```
-
-Avoid selecting plans with `-l pgroles.io/policy=<name>`. That label is a
-server-side prefilter truncated to 63 bytes, so it is not an identity and two
-policies sharing a long prefix select each other's plans.
-
-Plans above the inline size limit set `status.sqlRef` instead of `sqlInline`,
-naming a ConfigMap whose `plan.sql.gz` entry holds the gzipped SQL under
-`binaryData`. Fetching that takes a decode step:
-
-```bash
-CM="$(kubectl get pgplan "$PLAN" -o jsonpath='{.status.sqlRef.name}')"
-kubectl get configmap "$CM" -o jsonpath="{.binaryData['plan\.sql\.gz']}" |
-  base64 -d | gunzip
-```
-
-A plan whose compressed preview would still exceed the ConfigMap limit sets no
-`sqlRef` at all, and `status.sqlInline` carries a truncated preview ending in a
-`-- truncated: ... --` marker.
-
-The preview is a review artifact in every case. pgroles never executes stored
-SQL: an approved plan is re-rendered from the current diff at execution time and
-superseded if the hash no longer matches.
-
-Use `suspend` when you want the controller to stop reconciling entirely. Use `plan` when you want it to keep inspecting and showing you what it would do.
+Plans above the inline size limit set `status.sqlRef`, naming a ConfigMap
+whose `plan.sql.gz` entry holds the gzipped SQL. The preview is a review
+artifact in every case: **pgroles never executes stored SQL**.
 
 ## What executes: mode and approval together
 
@@ -124,142 +73,136 @@ order. Only the last one is about human review:
 | `suspend` | `mode` | `approval` | Plan created? | Mutating SQL executed? |
 |---|---|---|---|---|
 | `true` | — | — | no | no — nothing reconciles at all |
-| `false` | `plan` | *ignored* | yes | **never** |
+| `false` | `observe` | *ignored* | yes | **never** |
 | `false` | `apply` | `auto` | yes | immediately, plan auto-approved |
 | `false` | `apply` | `manual` | yes | only once approved *and* still current |
 
-**`approval` has no effect in `plan` mode.** A plan-mode policy computes the
-diff, publishes a `PostgresPolicyPlan`, and returns before it ever consults
-`approval`. Annotating that plan with `pgroles.io/approved=true` is accepted by
-the API server and then does nothing: the plan stays `Pending` and no database
-changes are applied.
-Because that is indistinguishable from a stalled operator, the policy reports an
-`ApprovalIgnored` condition naming the plan and emits a warning Event. If you
-want a reviewed apply, the combination you want is `mode: apply` with
-`approval: manual` — plan mode is for looking, not for gated applying.
+`approval` has no effect in `observe` mode; a decision recorded on an
+observe-mode plan is accepted and does nothing, and the policy reports an
+`ApprovalIgnored` condition so this is distinguishable from a stalled
+operator.
 
-Execution never trusts stored SQL. An approved plan is re-rendered from the
-current diff and its hash compared against the approved one, so the plan object
-is a review artifact rather than an execution payload.
+## Approval identity: the change digest
 
-### When the policy changes mid-review
+What a decision approves is the plan's **change digest**: a versioned hash
+(`pgroles.io/approval-effect/v1`) of the canonical, deterministically ordered
+typed effects — role lifecycle, grants, memberships, ownership and default
+privileges, retirements — bound together with the reconciliation mode, the
+managed scope, the applied-base digest, and the target identity.
 
-With `mode: apply` and `approval: manual`, a pending plan is **frozen** — the
-operator returns early while a plan awaits a decision, so it neither refreshes
-nor supersedes it. Two consequences worth knowing before you rely on the review
-step:
+The digest deliberately excludes anything that legitimately differs between
+planning and execution: cleartext passwords, SCRAM salts and verifiers, and
+renderer-specific SQL text. A password change is identified semantically as
+*(role, password source, source version)* — rotating the source Secret
+produces exactly one new plan, and re-planning an unchanged source produces
+the same digest every time. `status.sqlHash` still exists, but only as a
+diagnostic for the preview text; it is never the approval gate.
 
-- The policy's status reports the *freshly computed* change count each reconcile,
-  while the pending plan still holds the SQL from when it was created. Status and
-  plan can therefore disagree after a manifest change, and the plan is the stale
-  one.
-- Approving a stale plan does not apply it. On the next reconcile the hash
-  comparison fails, the plan is marked `Superseded`, and a **new** plan is
-  created awaiting approval. Nothing unsafe executes, but the approval is
-  consumed without effect and a second review round is required.
+Because identity is semantic, plans survive irrelevant change. A policy
+generation bump, an unrelated base edit, or unrelated ephemeral-access
+activity re-plans to an identical digest and the pending plan — including a
+decision already recorded on it — is retained, with the revalidated
+generation noted on its status.
 
-Check that the plan you are approving matches the current generation:
+## Deciding a plan
+
+A decision is a status write on the plan — one terminal condition and
+`status.decidedBy`, recorded together, exactly as `EphemeralAccessRequest`
+decisions work:
 
 ```bash
-kubectl get pgr <policy> -o jsonpath='{.metadata.generation}{"\n"}'
-kubectl get pgplan <plan> -o jsonpath='{.spec.policyGeneration}{"\n"}'
+pgroles plan approve orders-plan-9f21c4      # or: pgroles plan reject ...
 ```
 
-Everywhere else, a superseding write happens automatically: creating a plan marks
-any other `Pending` plan for the same policy `Superseded`, so plan mode and the
-first plan after an approval both converge on a single current plan.
+The CLI patches the plan's status subresource; raw `kubectl patch
+--subresource=status` works identically. The approval annotations from
+earlier releases are removed.
 
-Rejecting with `pgroles.io/rejected=true` marks the plan `Rejected` and clears
-`status.current_plan_ref`. The replacement is created on the *next* reconcile
-rather than immediately, which keeps a rejected plan from spinning in a
-reject-recreate loop.
+The trust model has two layers, and both matter:
 
-## Plan approval resources
+- **CEL validation rules** (shipped in the CRD) make decisions terminal and
+  write-once: `Approved=True` and `Denied=True` are mutually exclusive, a
+  recorded decision can never change, and `decidedBy` must be written in the
+  same operation as the decision.
+- **Actor identity requires the admission layer.** CEL cannot see the
+  requesting user, so `decidedBy` is truthful only when the shipped Kyverno
+  reference policy (or an equivalent mutating webhook) overwrites it from
+  admission `userInfo`. Without that layer, `decidedBy` is whatever the
+  client asserted. Deploy the reference policy anywhere approvals are a
+  control you rely on.
+
+Approval RBAC is per-kind: granting a team create on policies or candidates
+grants nothing on plan status. Execution settings (`approval`, managed scope)
+are platform-controlled — protect them with an admission policy so a policy
+author cannot weaken them in the same edit that introduces a change.
+
+## Plans stay current while awaiting review
+
+A pending plan is revalidated on every reconcile — there is no frozen-plan
+window. When the policy, database, target, or overlays change while a plan
+awaits a decision:
+
+- **effects unchanged** (identical change digest): the plan is retained, the
+  revalidated generation recorded; the policy's change summary and
+  `current_plan_ref` always describe the same plan.
+- **effects changed**: the plan is superseded with an explicit condition and
+  Event, and a fresh plan is created for review.
+
+Approving a plan therefore approves what the plan currently shows. If a
+supersede races your approval, the decision lands on a plan that is no longer
+current and nothing executes — the fresh plan awaits its own decision.
+
+Rejecting a plan marks it `Rejected` and clears `status.current_plan_ref`;
+the replacement is created on the next reconcile, which keeps a rejected plan
+from spinning in a reject-recreate loop.
+
+## Target identity
+
+Every plan binds the identity of the database it was computed against, at the
+strongest tier available:
+
+1. **Physical**: `pg_control_system().system_identifier`, when the server
+   exposes it.
+2. **Logical**: the resolved connection fingerprint — host, port, database
+   name — plus the connection Secret's version.
+
+Execution fails closed on a *mismatch* at either tier, and on a *tier
+downgrade* (the identifier was readable at approval but not at execution).
+Repointing the connection Secret at a different server therefore invalidates
+every approval made against the old one, even though the Kubernetes reference
+is unchanged. Environments where the physical identifier is consistently
+unavailable run on the logical tier; set `requirePhysicalIdentity: true` to
+refuse execution without tier 1.
+
+A target change is not an error to work around — it flows through the
+ordinary supersede-and-review path. The fresh approval is the sanctioned
+acknowledgement that the target moved.
+
+## Passwords and planning
+
+Planning is side-effect free in every mode. For `password.generate` roles the
+operator synthesizes in-memory material while planning and creates the real
+Kubernetes Secret only during post-approval execution — under `apply +
+manual` there is no generated Secret in the cluster until a reviewer has
+approved the plan that introduces it.
+
+## Execution
+
+Approval never executes a stored artifact. Under the same database and
+advisory lock, with no unlock window, the operator re-inspects, recomputes
+the effects, and verifies the recomputed change digest against the approved
+one. The statements executed are exactly the approved canonical effects
+recomputed against the state observed under that lock; any divergence aborts
+before the first statement and supersedes the plan.
+
+To review proposed changes *without* editing the active policy at all, see
+[Candidates and promotion](/docs/operator-candidates).
 
 {% callout type="warning" title="Set `spec.approval` explicitly" %}
-`spec.approval` decides whether a human gates SQL execution. When it is omitted
-the operator still infers it from `spec.mode` — `apply` implies `auto`, `plan`
-implies `manual` — which leaves that gate invisible on the object: nothing in
-`kubectl get pgr -o yaml` tells you whether the policy applies DDL on its own.
-
-That inference is deprecated. A policy relying on it reports an `ApprovalUnset`
-status condition naming the inferred value, emits a warning Event, and counts
-toward the `pgroles.deprecated.approval_unset` metric. A future release will
-reject a policy that omits the field.
-
-Write down the value you are already getting — `approval: auto` for a policy in
-`mode: apply`, `approval: manual` for `mode: plan` — and the condition clears on
-the next reconcile with no change in behaviour.
+`spec.approval` decides whether a human gates SQL execution. When omitted the
+operator still infers it from `spec.mode` — `apply` implies `auto`, `observe`
+implies `manual` — which leaves the gate invisible on the object. That
+inference is deprecated: a policy relying on it reports an `ApprovalUnset`
+condition, emits a warning Event, and counts toward
+`pgroles.deprecated.approval_unset`. Write the value down explicitly.
 {% /callout %}
-
-When `spec.approval: manual` is used with `mode: apply`, the operator creates a `PostgresPolicyPlan` and waits for approval instead of immediately executing the SQL.
-
-```yaml
-spec:
-  connection:
-    secretRef:
-      name: postgres-credentials
-  mode: apply
-  approval: manual
-```
-
-A generated plan looks like this:
-
-```text
-NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
-plan-approval-policy-plan-20260512-090318-454373251739   plan-approval-policy   authoritative   False      2         Pending   3s
-```
-
-Approve it by annotating the plan:
-
-```shell
-kubectl annotate pgplan plan-approval-policy-plan-20260512-090318-454373251739 \
-  pgroles.io/approved=true --overwrite
-```
-
-After approval, the plan moves to `Applied`:
-
-```text
-NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
-plan-approval-policy-plan-20260512-090318-454373251739   plan-approval-policy   authoritative   True       2         Applied   5s
-```
-
-The plan status included:
-
-```yaml
-status:
-  appliedAt: "2026-05-12T09:03:21Z"
-  changeSummary:
-    grants_added: 1
-    roles_created: 1
-    total: 2
-  conditions:
-    - type: Computed
-      status: "True"
-      reason: PlanComputed
-      message: Plan computed with 2 change(s)
-    - type: Approved
-      status: "True"
-      reason: Approved
-      message: Plan approved and executed
-  phase: Applied
-  sqlHash: 454373251739fdfbe188ae07358b01d9e0465eb47011fe2d4f386fa34ef7de1b
-  sqlInline: |-
-    CREATE ROLE "approval_test_user" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
-    GRANT CONNECT ON DATABASE "postgres" TO "approval_test_user";
-  sqlStatements: 2
-  sqlTruncated: false
-```
-
-With `spec.approval: auto`, the operator creates a `PostgresPolicyPlan` and applies it immediately:
-
-```text
-NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
-auto-approval-policy-plan-20260512-090329-11a6ca1d7c09   auto-approval-policy   authoritative   True       2         Applied   2s
-```
-
-The corresponding database role is present after reconcile:
-
-```text
-auto_approved_user
-```

--- a/docs/src/pages/docs/operator-plan-approval.md
+++ b/docs/src/pages/docs/operator-plan-approval.md
@@ -53,7 +53,8 @@ one coherent (drift visibility without a stream of permission-denied errors).
 For a reviewed apply, use `mode: apply` with `approval: manual`. Use `suspend`
 to stop reconciling entirely.
 
-The rendered SQL lives on the plan; follow `current_plan_ref` to it:
+The rendered SQL lives on the plan; follow `current_plan_ref` to it. Small
+plans carry it inline:
 
 ```bash
 POLICY=observed-policy
@@ -61,9 +62,22 @@ PLAN="$(kubectl get pgr "$POLICY" -o jsonpath='{.status.current_plan_ref.name}')
 kubectl get pgplan "$PLAN" -o jsonpath='{.status.sqlInline}'
 ```
 
-Plans above the inline size limit set `status.sqlRef`, naming a ConfigMap
-whose `plan.sql.gz` entry holds the gzipped SQL. The preview is a review
-artifact in every case: **pgroles never executes stored SQL**.
+Plans above the inline size limit leave `sqlInline` empty and set
+`status.sqlRef` instead, naming a ConfigMap whose `plan.sql.gz` entry holds
+the gzipped SQL — so the command above prints nothing for a large plan.
+Fetching that takes a decode step:
+
+```bash
+CM="$(kubectl get pgplan "$PLAN" -o jsonpath='{.status.sqlRef.name}')"
+kubectl get configmap "$CM" -o jsonpath="{.binaryData['plan\.sql\.gz']}" |
+  base64 -d | gunzip
+```
+
+`pgroles plan show <plan>` follows whichever branch applies. A plan whose
+compressed preview would still exceed the ConfigMap limit sets no `sqlRef`,
+and `sqlInline` carries a truncated preview ending in a `-- truncated: ... --`
+marker. The preview is a review artifact in every case: **pgroles never
+executes stored SQL**.
 
 ## What executes: mode and approval together
 
@@ -88,7 +102,16 @@ What a decision approves is the plan's **change digest**: a versioned hash
 (`pgroles.io/approval-effect/v1`) of the canonical, deterministically ordered
 typed effects — role lifecycle, grants, memberships, ownership and default
 privileges, retirements — bound together with the reconciliation mode, the
-managed scope, the applied-base digest, and the target identity.
+managed scope, and the target identity.
+
+The applied base is deliberately *not* a digest input. The plan records which
+base it was computed against as provenance, and that record advances whenever
+revalidation confirms the effects are unchanged. Hashing the base in would
+make every unrelated policy edit invalidate every pending approval, which is
+exactly the churn semantic identity exists to prevent. What the base record
+does buy is the promotion check: execution requires the promoted content to
+match the approved candidate *and* the base to be the one the plan last
+revalidated against.
 
 The digest deliberately excludes anything that legitimately differs between
 planning and execution: cleartext passwords, SCRAM salts and verifiers, and
@@ -113,6 +136,13 @@ decisions work:
 ```bash
 pgroles plan approve orders-plan-9f21c4      # or: pgroles plan reject ...
 ```
+
+There is one rejection model across the product. A rejected plan records
+`Denied=True` with reason `DeniedByReviewer` and moves to phase `Rejected`;
+`Approved=True` and `Denied=True` are mutually exclusive and neither can be
+changed once written. ("Rejected" is the phase; `Denied` is the condition —
+they always travel together.) A candidate whose plan is denied is terminal
+too, reporting `Superseded=True, reason=PlanDenied`.
 
 The CLI patches the plan's status subresource; raw `kubectl patch
 --subresource=status` works identically. The approval annotations from
@@ -152,9 +182,11 @@ Approving a plan therefore approves what the plan currently shows. If a
 supersede races your approval, the decision lands on a plan that is no longer
 current and nothing executes — the fresh plan awaits its own decision.
 
-Rejecting a plan marks it `Rejected` and clears `status.current_plan_ref`;
-the replacement is created on the next reconcile, which keeps a rejected plan
-from spinning in a reject-recreate loop.
+Rejecting a plan — `Denied=True`, phase `Rejected`, as above — clears
+`status.current_plan_ref` on the policy. The replacement is created on the
+next reconcile rather than immediately, which keeps a rejected plan from
+spinning in a reject-recreate loop. For a candidate's plan there is no
+replacement: fix the proposal by filing a successor candidate.
 
 ## Target identity
 


### PR DESCRIPTION
First PR in the #173 stack: documentation-driven design. These pages document the *target* design as if fully implemented, so the design gets reviewed in the form users will meet it. Both pages open with a design-preview callout naming what is and isn't released, so merging ahead of implementation doesn't mislead readers of the live site.

## New page: Candidates and promotion (`operator-candidates.md`)

Documents `PostgresPolicyCandidate` end to end:

- what a candidate is (one-shot immutable proposal, CSR-shaped; never enforceable; per-kind authority split)
- the full workflow: CI files candidate → operator plans it in the parent's lock/context → reviewer decides the plan (the single operator-checked approval) → GitOps merge is *promotion*, verified pre-merge by `pgroles candidate verify`
- semantic staleness: replan on base/overlay change, identical change digest retains plan **and decision**; `OverlayOverlap` supersedes with explicit condition
- no base pin in spec — the plan binds the applied base it observed
- iteration by replacement (`generateName`, `spec.replaces`); supersession never inferred from creator identity
- promotion edge cases as a table, including the honest enforcement-gap note after a mismatched promotion
- target-override migration preview, retention/GC, conditions table

## Rewritten: Plan and approval (`operator-plan-approval.md`)

End state of Phase 0:

- `mode: observe` (renamed from `plan`), with the honest framing that a mode is not a security boundary — a read-only credential is
- the change digest (`pgroles.io/approval-effect/v1`) as approval identity; `sqlHash` demoted to diagnostics; passwords identified as *(role, source, source version)*
- decisions as write-once status writes with `decidedBy` (annotations removed), with the two-layer trust model spelled out: CEL enforces terminality, the Kyverno reference policy makes identity truthful
- continuous pending-plan revalidation (no frozen-plan window; identical digest retained, changed digest superseded)
- tiered target identity (physical `system_identifier` → logical fingerprint; fail closed on mismatch or tier downgrade; `requirePhysicalIdentity` opt-in)
- side-effect-free planning in every mode (generated Secrets only post-approval)
- execution defined as an outcome: the effects executed are exactly the approved canonical effects recomputed under the lock

Also adds the sidebar entry.

## Verification

- `cd docs && npm run build` — exit 0, all pages prerender including `/docs/operator-candidates`
- Content matches the refined design in #173 after its adversarial review pass

Part of #173.

https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added navigation for candidate policies and promotion workflows.
  * Documented immutable policy candidates for proposing, reviewing, and promoting redacted policy effects without modifying or executing the active policy.
  * Expanded plan approval guidance, including observe mode, approval decisions, digest validation, target identity checks, revalidation, retention, and execution safeguards.
  * Added details on GitOps promotion, connection migration previews, conditions, and content-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->