### PR TITLE
feat(operator): approve plans by semantic effect digest, not rendered SQL

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -193,6 +193,16 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "changeDigest": {
+                    "description": "Canonical semantic digest of the plan's typed effects, bound to the\nreconciliation mode and target database identity.\n\nThis is the approval identity: a decision approves these effects, and\nexecution proceeds only when the recomputed digest still matches. It is\nstable across recomputation of unchanged effects — notably for password\nchanges, which bind the password *source* rather than the derived\nverifier. See `pgroles_core::approval`.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "changeDigestEncoding": {
+                    "description": "Version tag of the encoding `change_digest` was computed under. Digests\nfrom different encodings are never comparable.",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "changeSummary": {
                     "description": "Summary of changes in this plan.",
                     "nullable": true,
@@ -343,7 +353,7 @@
                     "type": "string"
                   },
                   "sqlHash": {
-                    "description": "SHA-256 hash of the planned SQL, used to detect duplicate plans.\nIf a newly computed plan has the same hash as the current pending plan,\nthe operator can skip creating a redundant plan.",
+                    "description": "SHA-256 hash of the planned SQL. Retained as a diagnostic for the\npreview artifact; it is **not** the approval identity, because rendered\nSQL embeds a freshly salted SCRAM verifier for every password change.\nUse `change_digest` for approval and deduplication.",
                     "nullable": true,
                     "type": "string"
                   },

--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -348,7 +348,7 @@
                     "type": "string"
                   },
                   "redactedSqlHash": {
-                    "description": "SHA-256 hash of the redacted SQL preview bytes. This is for storage\nintegrity only; approval and deduplication continue to use `sql_hash`.",
+                    "description": "SHA-256 hash of the redacted SQL preview bytes. This is for storage\nintegrity only; approval and deduplication use `change_digest`.",
                     "nullable": true,
                     "type": "string"
                   },

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -39,9 +39,25 @@ Verifies what an approval actually binds, by separating two things
 The constant `SqlHashApproval` selects the approval gate:
 
 ```sh
-./run-tlc.sh races/PlanApproval.tla races/PlanApproval.cfg        # digest gate: passes
-./run-tlc.sh races/PlanApproval.tla races/PlanApproval_buggy.cfg  # SQL-hash gate: liveness violated
+./run-tlc.sh races/PlanApproval.tla races/PlanApproval.cfg           # passes
+./run-tlc.sh races/PlanApproval.tla races/PlanApproval_buggy.cfg     # liveness violated (#174)
+./run-tlc.sh races/PlanApproval.tla races/PlanApproval_unlocked.cfg  # NoStaleExecution violated
 ```
+
+Each configuration demonstrates a distinct requirement:
+
+| Config | `SqlHashApproval` | `LockDuringApply` | Result |
+| --- | --- | --- | --- |
+| `PlanApproval.cfg` | FALSE | TRUE | passes |
+| `PlanApproval_buggy.cfg` | TRUE | TRUE | `EventuallyApplies` violated |
+| `PlanApproval_unlocked.cfg` | FALSE | FALSE | `NoStaleExecution` violated |
+
+`PlanApproval_unlocked.cfg` shows why verification and execution must share one
+lock hold: with drift permitted while a plan is `Applying`, what executes no
+longer matches the state it was verified against. `NoStaleExecution` records a
+witness at apply time rather than comparing `appliedEffects` to `dbEffects` as a
+state invariant — the database may legitimately drift again after a successful
+apply, and a plain comparison would fire on that instead of on a stale one.
 
 The buggy configuration reproduces issue #174. A `SetPassword` change embeds a
 SCRAM verifier built with a fresh random salt on every computation, so a

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -25,6 +25,37 @@ Races modeled:
 4. Database drift changes between plan creation and approval
 5. Hash dedup skips identical plans
 
+### `races/PlanApproval.tla`
+
+Verifies what an approval actually binds, by separating two things
+`PlanLifecycle.tla` conflates: the *semantic effects* of a plan, and the
+*rendered SQL* those effects produce.
+
+- Nothing executes without a recorded approval of the plan being executed
+- What executed is what was reviewed, never a different set of effects
+- An approval never carries across a change in effects
+- **Liveness**: once drift stops, a plan is eventually applied
+
+The constant `SqlHashApproval` selects the approval gate:
+
+```sh
+./run-tlc.sh races/PlanApproval.tla races/PlanApproval.cfg        # digest gate: passes
+./run-tlc.sh races/PlanApproval.tla races/PlanApproval_buggy.cfg  # SQL-hash gate: liveness violated
+```
+
+The buggy configuration reproduces issue #174. A `SetPassword` change embeds a
+SCRAM verifier built with a fresh random salt on every computation, so a
+rendered-SQL gate can never be satisfied: at approve time the operator
+re-renders, the hash differs, the reviewed plan is superseded, and the
+replacement has the same problem. TLC reports a violation of
+`EventuallyApplies` with a `Back to state ... OperatorSupersedes` lasso — the
+endless approve/supersede cycle.
+
+Note that every *safety* invariant still holds in the buggy configuration.
+Nothing unsafe executes; the workflow simply never converges. That is why the
+bug survived a safety-focused test suite, and why this model checks a temporal
+property rather than only invariants.
+
 ### `races/PlanStorage.tla`
 
 Verifies the Kubernetes persistence ordering around plan SQL previews:

--- a/correctness/races/PlanApproval.cfg
+++ b/correctness/races/PlanApproval.cfg
@@ -1,0 +1,22 @@
+\* Approval binds the canonical semantic effect digest (the shipped design).
+\* Safety holds and the workflow converges even for password-bearing plans.
+
+SPECIFICATION Spec
+
+\* Reaching Applied is a terminal success state with no further actions
+\* enabled; that is convergence, not a deadlock.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    SqlHashApproval = FALSE
+    HasPasswordChange = TRUE
+    MaxDrifts = 1
+
+INVARIANT
+    TypeOK
+    NoUnreviewedExecution
+    ExecutedWhatWasApproved
+    NoStaleExecution
+
+PROPERTY
+    EventuallyApplies

--- a/correctness/races/PlanApproval.cfg
+++ b/correctness/races/PlanApproval.cfg
@@ -9,6 +9,7 @@ CHECK_DEADLOCK FALSE
 
 CONSTANTS
     SqlHashApproval = FALSE
+    LockDuringApply = TRUE
     HasPasswordChange = TRUE
     MaxDrifts = 1
 

--- a/correctness/races/PlanApproval.tla
+++ b/correctness/races/PlanApproval.tla
@@ -38,6 +38,8 @@ EXTENDS FiniteSets, Naturals
 
 CONSTANTS
     SqlHashApproval,     \* TRUE reproduces the #174 rendered-SQL gate
+    LockDuringApply,     \* TRUE models verification and execution happening
+                         \* under one lock hold with no unlock window
     HasPasswordChange,   \* TRUE when the change set contains a SetPassword
     MaxDrifts            \* Bound on external database drift, so the system
                          \* eventually quiesces and liveness is meaningful
@@ -62,10 +64,16 @@ VARIABLES
     approved,         \* A reviewer has recorded approval of this exact plan
     dbEffects,        \* Effects the policy would produce against the live database
     driftsLeft,       \* Remaining external database changes
-    appliedEffects    \* Effects that actually executed (for safety checking)
+    appliedEffects,   \* Effects that actually executed (for safety checking)
+    appliedInSync     \* Whether, *at the moment of execution*, the executed
+                      \* effects still matched the live database. Recorded as a
+                      \* witness because the database may legitimately drift
+                      \* again afterwards — a plain state invariant comparing
+                      \* appliedEffects to dbEffects would fire on that normal
+                      \* post-apply drift instead of on a stale execution.
 
 vars == <<planPhase, planEffects, planRenderStale, approved, dbEffects,
-          driftsLeft, appliedEffects>>
+          driftsLeft, appliedEffects, appliedInSync>>
 
 TypeOK ==
     /\ planPhase \in {NoPlan, Pending, Applying, Applied}
@@ -75,6 +83,7 @@ TypeOK ==
     /\ dbEffects \in Effects
     /\ driftsLeft \in 0..MaxDrifts
     /\ appliedEffects \in Effects \cup {NoEffects}
+    /\ appliedInSync \in BOOLEAN
 
 \* --- The approval gate ---
 
@@ -98,11 +107,16 @@ NoUnreviewedExecution ==
 ExecutedWhatWasApproved ==
     (planPhase = Applied) => appliedEffects = planEffects
 
-\* Approval never carries across a change in effects: if the database moved
-\* away from the reviewed effects, nothing from that plan executed.
+\* What executed matches the database state it was verified against — no drift
+\* slipped in between the gate check and execution.
+\*
+\* Note this compares against `dbEffects`, not `planEffects`: comparing to
+\* `planEffects` would merely restate ExecutedWhatWasApproved and could never
+\* observe drift. This is the property that requires verification and execution
+\* to share one lock hold; with LockDuringApply = FALSE, TLC finds the stale
+\* apply (see PlanApproval_unlocked.cfg).
 NoStaleExecution ==
-    (planPhase = Applied /\ appliedEffects /= NoEffects) =>
-        appliedEffects = planEffects
+    (planPhase = Applied /\ appliedEffects /= NoEffects) => appliedInSync
 
 \* --- Liveness ---
 
@@ -118,19 +132,25 @@ Init ==
     /\ dbEffects = "e1"
     /\ driftsLeft = MaxDrifts
     /\ appliedEffects = NoEffects
+    /\ appliedInSync = TRUE
 
 \* --- Actions ---
 
 \* External modification to the database changes what the policy would do.
 \* Bounded by MaxDrifts so the system eventually quiesces.
+\*
+\* While the operator is executing it holds the database and advisory locks, so
+\* nothing can change underneath it — the design's "no unlock window" between
+\* pre-execution verification and execution.
 DatabaseDrifts ==
+    /\ LockDuringApply => planPhase /= Applying
     /\ driftsLeft > 0
     /\ \E e \in Effects:
         /\ e /= dbEffects
         /\ dbEffects' = e
     /\ driftsLeft' = driftsLeft - 1
     /\ UNCHANGED <<planPhase, planEffects, planRenderStale, approved,
-                    appliedEffects>>
+                    appliedEffects, appliedInSync>>
 
 \* The operator computes a plan for the current effects.
 OperatorCreatesPlan ==
@@ -139,7 +159,7 @@ OperatorCreatesPlan ==
     /\ planEffects' = dbEffects
     /\ planRenderStale' = FALSE   \* Freshly rendered and stored together
     /\ approved' = FALSE
-    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects>>
+    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects, appliedInSync>>
 
 \* A reviewer approves the pending plan.
 UserApproves ==
@@ -147,7 +167,7 @@ UserApproves ==
     /\ ~approved
     /\ approved' = TRUE
     /\ UNCHANGED <<planPhase, planEffects, planRenderStale, dbEffects,
-                    driftsLeft, appliedEffects>>
+                    driftsLeft, appliedEffects, appliedInSync>>
 
 \* Before executing, the operator recomputes the diff and re-renders the SQL.
 \*
@@ -161,7 +181,7 @@ OperatorRevalidates ==
     /\ HasPasswordChange
     /\ planRenderStale' = TRUE
     /\ UNCHANGED <<planPhase, planEffects, approved, dbEffects, driftsLeft,
-                    appliedEffects>>
+                    appliedEffects, appliedInSync>>
 
 \* The gate passes: execute the reviewed effects.
 OperatorExecutes ==
@@ -171,7 +191,7 @@ OperatorExecutes ==
     /\ GatePasses
     /\ planPhase' = Applying
     /\ UNCHANGED <<planEffects, planRenderStale, approved, dbEffects,
-                    driftsLeft, appliedEffects>>
+                    driftsLeft, appliedEffects, appliedInSync>>
 
 \* The gate fails: supersede the reviewed plan and start a fresh one.
 \*
@@ -187,12 +207,15 @@ OperatorSupersedes ==
     /\ planEffects' = dbEffects
     /\ planRenderStale' = FALSE
     /\ approved' = FALSE          \* The replacement needs its own decision
-    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects>>
+    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects, appliedInSync>>
 
 ApplySucceeds ==
     /\ planPhase = Applying
     /\ planPhase' = Applied
     /\ appliedEffects' = planEffects
+    \* The witness: did the database still hold the verified state when the
+    \* statements ran? Under a single lock hold it must have.
+    /\ appliedInSync' = (planEffects = dbEffects)
     /\ UNCHANGED <<planEffects, planRenderStale, approved, dbEffects,
                     driftsLeft>>
 

--- a/correctness/races/PlanApproval.tla
+++ b/correctness/races/PlanApproval.tla
@@ -1,0 +1,222 @@
+---- MODULE PlanApproval ----
+EXTENDS FiniteSets, Naturals
+
+(*
+  Approval identity model for pgroles PostgresPolicyPlan.
+
+  `PlanLifecycle.tla` models the plan state machine assuming one hash stands
+  for both "what the reviewer approved" and "what would execute now". This
+  model separates the two, because they are not the same thing:
+
+    - the *semantic effects* of a plan (typed changes: roles, grants,
+      memberships, ...), which are stable while policy, database and password
+      sources are unchanged
+    - the *rendered SQL* those effects produce, which for a password change
+      embeds a SCRAM-SHA-256 verifier built with a fresh random salt on every
+      computation, and therefore differs on every recomputation
+
+  Gating approval on rendered SQL makes a password-bearing plan impossible to
+  approve: at approve time the operator re-renders, the hash differs, the
+  reviewed plan is superseded, and the replacement has the same problem. That
+  is issue #174, and it is a *liveness* failure — nothing unsafe executes, but
+  the workflow never converges. Safety invariants alone cannot see it.
+
+  The constant `SqlHashApproval` selects the gate:
+
+    - FALSE (PlanApproval.cfg)       — approval binds the semantic effect
+                                       digest. Safety and liveness hold.
+    - TRUE  (PlanApproval_buggy.cfg) — approval binds the rendered SQL hash,
+                                       reproducing #174. TLC reports a
+                                       liveness violation: an endless
+                                       approve/supersede cycle.
+
+  What is NOT modeled:
+    - the encoding of the digest itself (see pgroles_core::approval)
+    - operator crashes and lock contention (covered by PlanLifecycle.tla)
+    - SQL execution against a real database
+*)
+
+CONSTANTS
+    SqlHashApproval,     \* TRUE reproduces the #174 rendered-SQL gate
+    HasPasswordChange,   \* TRUE when the change set contains a SetPassword
+    MaxDrifts            \* Bound on external database drift, so the system
+                         \* eventually quiesces and liveness is meaningful
+
+\* Plan phases relevant to approval. Rejection and crash recovery are
+\* PlanLifecycle.tla's business.
+NoPlan == "none"
+Pending == "Pending"
+Applying == "Applying"
+Applied == "Applied"
+
+\* Distinct semantic effect sets, standing in for change digests.
+Effects == {"e1", "e2"}
+NoEffects == "none"
+
+VARIABLES
+    planPhase,        \* Phase of the active plan
+    planEffects,      \* Semantic effects the plan was computed from
+    planRenderStale,  \* The stored rendered SQL no longer matches a fresh
+                      \* render of the same effects (true once re-rendered
+                      \* for a password-bearing change set)
+    approved,         \* A reviewer has recorded approval of this exact plan
+    dbEffects,        \* Effects the policy would produce against the live database
+    driftsLeft,       \* Remaining external database changes
+    appliedEffects    \* Effects that actually executed (for safety checking)
+
+vars == <<planPhase, planEffects, planRenderStale, approved, dbEffects,
+          driftsLeft, appliedEffects>>
+
+TypeOK ==
+    /\ planPhase \in {NoPlan, Pending, Applying, Applied}
+    /\ planEffects \in Effects \cup {NoEffects}
+    /\ planRenderStale \in BOOLEAN
+    /\ approved \in BOOLEAN
+    /\ dbEffects \in Effects
+    /\ driftsLeft \in 0..MaxDrifts
+    /\ appliedEffects \in Effects \cup {NoEffects}
+
+\* --- The approval gate ---
+
+\* Whether execution is permitted for the currently approved plan.
+\*
+\* Both gates require the reviewed effects to still be the effects the policy
+\* would produce. The rendered-SQL gate *additionally* requires the freshly
+\* rendered text to match what was stored — which a password change can never
+\* satisfy.
+GatePasses ==
+    /\ planEffects = dbEffects
+    /\ (SqlHashApproval => ~planRenderStale)
+
+\* --- Safety invariants ---
+
+\* Nothing executes without a recorded approval of the plan being executed.
+NoUnreviewedExecution ==
+    (planPhase \in {Applying, Applied}) => approved
+
+\* What executed is what was reviewed — never a different set of effects.
+ExecutedWhatWasApproved ==
+    (planPhase = Applied) => appliedEffects = planEffects
+
+\* Approval never carries across a change in effects: if the database moved
+\* away from the reviewed effects, nothing from that plan executed.
+NoStaleExecution ==
+    (planPhase = Applied /\ appliedEffects /= NoEffects) =>
+        appliedEffects = planEffects
+
+\* --- Liveness ---
+
+\* The workflow converges: once drift stops, a plan is eventually applied.
+\* This is the property #174 violates.
+EventuallyApplies == <>(planPhase = Applied)
+
+Init ==
+    /\ planPhase = NoPlan
+    /\ planEffects = NoEffects
+    /\ planRenderStale = FALSE
+    /\ approved = FALSE
+    /\ dbEffects = "e1"
+    /\ driftsLeft = MaxDrifts
+    /\ appliedEffects = NoEffects
+
+\* --- Actions ---
+
+\* External modification to the database changes what the policy would do.
+\* Bounded by MaxDrifts so the system eventually quiesces.
+DatabaseDrifts ==
+    /\ driftsLeft > 0
+    /\ \E e \in Effects:
+        /\ e /= dbEffects
+        /\ dbEffects' = e
+    /\ driftsLeft' = driftsLeft - 1
+    /\ UNCHANGED <<planPhase, planEffects, planRenderStale, approved,
+                    appliedEffects>>
+
+\* The operator computes a plan for the current effects.
+OperatorCreatesPlan ==
+    /\ planPhase = NoPlan
+    /\ planPhase' = Pending
+    /\ planEffects' = dbEffects
+    /\ planRenderStale' = FALSE   \* Freshly rendered and stored together
+    /\ approved' = FALSE
+    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects>>
+
+\* A reviewer approves the pending plan.
+UserApproves ==
+    /\ planPhase = Pending
+    /\ ~approved
+    /\ approved' = TRUE
+    /\ UNCHANGED <<planPhase, planEffects, planRenderStale, dbEffects,
+                    driftsLeft, appliedEffects>>
+
+\* Before executing, the operator recomputes the diff and re-renders the SQL.
+\*
+\* For a password-bearing change set this yields a fresh SCRAM verifier, so
+\* the stored rendered SQL is now stale even though the effects are identical.
+\* This is the step that makes the rendered-SQL gate unsatisfiable.
+OperatorRevalidates ==
+    /\ planPhase = Pending
+    /\ approved
+    /\ ~planRenderStale
+    /\ HasPasswordChange
+    /\ planRenderStale' = TRUE
+    /\ UNCHANGED <<planPhase, planEffects, approved, dbEffects, driftsLeft,
+                    appliedEffects>>
+
+\* The gate passes: execute the reviewed effects.
+OperatorExecutes ==
+    /\ planPhase = Pending
+    /\ approved
+    /\ (HasPasswordChange => planRenderStale)  \* Revalidation has happened
+    /\ GatePasses
+    /\ planPhase' = Applying
+    /\ UNCHANGED <<planEffects, planRenderStale, approved, dbEffects,
+                    driftsLeft, appliedEffects>>
+
+\* The gate fails: supersede the reviewed plan and start a fresh one.
+\*
+\* With the digest gate this happens only when the effects genuinely changed.
+\* With the rendered-SQL gate it also happens for an unchanged password
+\* source — the #174 loop.
+OperatorSupersedes ==
+    /\ planPhase = Pending
+    /\ approved
+    /\ (HasPasswordChange => planRenderStale)
+    /\ ~GatePasses
+    /\ planPhase' = Pending
+    /\ planEffects' = dbEffects
+    /\ planRenderStale' = FALSE
+    /\ approved' = FALSE          \* The replacement needs its own decision
+    /\ UNCHANGED <<dbEffects, driftsLeft, appliedEffects>>
+
+ApplySucceeds ==
+    /\ planPhase = Applying
+    /\ planPhase' = Applied
+    /\ appliedEffects' = planEffects
+    /\ UNCHANGED <<planEffects, planRenderStale, approved, dbEffects,
+                    driftsLeft>>
+
+Next ==
+    \/ DatabaseDrifts
+    \/ OperatorCreatesPlan
+    \/ UserApproves
+    \/ OperatorRevalidates
+    \/ OperatorExecutes
+    \/ OperatorSupersedes
+    \/ ApplySucceeds
+
+\* Weak fairness on every progress action: the operator keeps reconciling and
+\* the reviewer keeps reviewing. Drift is deliberately *not* fair — it is
+\* bounded and may stop at any time, which is what makes convergence
+\* meaningful to ask about.
+Fairness ==
+    /\ WF_vars(OperatorCreatesPlan)
+    /\ WF_vars(UserApproves)
+    /\ WF_vars(OperatorRevalidates)
+    /\ WF_vars(OperatorExecutes)
+    /\ WF_vars(OperatorSupersedes)
+    /\ WF_vars(ApplySucceeds)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+====

--- a/correctness/races/PlanApproval_buggy.cfg
+++ b/correctness/races/PlanApproval_buggy.cfg
@@ -11,6 +11,7 @@ CHECK_DEADLOCK FALSE
 
 CONSTANTS
     SqlHashApproval = TRUE
+    LockDuringApply = TRUE
     HasPasswordChange = TRUE
     MaxDrifts = 1
 

--- a/correctness/races/PlanApproval_buggy.cfg
+++ b/correctness/races/PlanApproval_buggy.cfg
@@ -1,0 +1,24 @@
+\* Approval binds the rendered SQL hash, as pgroles did before #174 was fixed.
+\* Safety still holds — nothing unsafe executes — but the workflow never
+\* converges: TLC reports a violation of EventuallyApplies, the endless
+\* approve/supersede cycle described in the issue.
+
+SPECIFICATION Spec
+
+\* Reaching Applied is a terminal success state with no further actions
+\* enabled; that is convergence, not a deadlock.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    SqlHashApproval = TRUE
+    HasPasswordChange = TRUE
+    MaxDrifts = 1
+
+INVARIANT
+    TypeOK
+    NoUnreviewedExecution
+    ExecutedWhatWasApproved
+    NoStaleExecution
+
+PROPERTY
+    EventuallyApplies

--- a/correctness/races/PlanApproval_unlocked.cfg
+++ b/correctness/races/PlanApproval_unlocked.cfg
@@ -1,0 +1,24 @@
+\* Approval binds the semantic digest, but verification and execution do NOT
+\* share a lock hold. TLC reports a violation of NoStaleExecution: the database
+\* drifts while the plan is Applying, so what executes no longer matches the
+\* state it was verified against. This is why the design requires a single lock
+\* hold with no unlock window.
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    SqlHashApproval = FALSE
+    LockDuringApply = FALSE
+    HasPasswordChange = TRUE
+    MaxDrifts = 1
+
+INVARIANT
+    TypeOK
+    NoUnreviewedExecution
+    ExecutedWhatWasApproved
+    NoStaleExecution
+
+PROPERTY
+    EventuallyApplies

--- a/crates/pgroles-core/src/approval.rs
+++ b/crates/pgroles-core/src/approval.rs
@@ -351,6 +351,42 @@ mod tests {
         assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
+    /// Pin the exact canonical bytes for a fixed input.
+    ///
+    /// The digest is only stable if the serialization is. `serde_json` emits
+    /// object keys in declaration order by default, but its `preserve_order`
+    /// feature switches to insertion order — and any dependency in the graph
+    /// can enable it, silently changing every digest without changing
+    /// `APPROVAL_EFFECT_ENCODING_V1`. Pending approvals would then be
+    /// superseded across an unrelated dependency bump.
+    ///
+    /// Note the object keys come out *alphabetically*, not in struct
+    /// declaration order, because effects round-trip through
+    /// `serde_json::Value`, whose `Object` is `BTreeMap`-backed. That is a
+    /// useful property — reordering fields in `Change` cannot change a digest
+    /// — and `preserve_order` is exactly what would take it away.
+    ///
+    /// If this test fails, the encoding changed: bump the encoding constant
+    /// deliberately rather than updating the expected bytes in place.
+    #[test]
+    fn canonical_bytes_are_pinned_for_a_fixed_input() {
+        let versions = versions(&[("app", "role-passwords:app:7")]);
+        let changes = [
+            grant("reporting"),
+            set_password("app", "SCRAM-SHA-256$4096:salt$stored:server"),
+        ];
+
+        let bytes = canonical_change_set_bytes(&changes, &inputs(&versions)).expect("bytes");
+        let encoded = String::from_utf8(bytes).expect("canonical bytes are UTF-8 JSON");
+
+        assert_eq!(
+            encoded,
+            r#"{"effect_encoding":"pgroles.io/approval-effect/v1","reconciliation_mode":"Authoritative","target":"default/postgres-credentials:url","effects":[{"Grant":{"name":"orders","object_type":"table","privileges":["SELECT"],"role":"reporting","schema":"inventory"}},{"SetPassword":{"name":"app","password_source":"role-passwords:app:7"}}]}"#,
+            "canonical encoding changed; bump APPROVAL_EFFECT_ENCODING_V1 rather than \
+             editing this fixture"
+        );
+    }
+
     #[test]
     fn the_digest_never_contains_password_material() {
         let versions = versions(&[("app", "role-passwords:app:7")]);

--- a/crates/pgroles-core/src/approval.rs
+++ b/crates/pgroles-core/src/approval.rs
@@ -1,0 +1,354 @@
+//! Canonical approval-effect digest.
+//!
+//! An approval must name the *semantic effects* a plan will have, not the SQL
+//! text those effects happen to render to. Rendered SQL is unstable in ways
+//! that have nothing to do with what a reviewer approved: a `SetPassword`
+//! change embeds a SCRAM-SHA-256 verifier built with a fresh random salt on
+//! every computation, so hashing the SQL makes a password-bearing plan
+//! impossible to approve — it is superseded the moment the diff is recomputed.
+//!
+//! This module defines a versioned canonical encoding of the typed effects,
+//! following the same discipline as the ephemeral bundle hash: a named
+//! encoding constant, deterministic serialization, and a self-verifying
+//! SHA-256 digest.
+//!
+//! What the encoding binds:
+//!
+//! - every typed [`Change`], normalized and ordered independently of the diff
+//!   engine's dependency ordering
+//! - the reconciliation mode, since the same desired state converges
+//!   differently under `additive` or `adopt`
+//! - the target database identity, so an approval cannot be reused against a
+//!   different server
+//!
+//! What it deliberately excludes:
+//!
+//! - cleartext passwords, generated password material, SCRAM salts and
+//!   verifiers — a password change is bound as `(role, password source
+//!   identity and version)` instead
+//! - rendered SQL text, statement ordering, and renderer-specific formatting
+//!
+//! The rendered-SQL hash remains useful as a diagnostic for the preview
+//! artifact; it is simply not the approval identity.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::diff::{Change, ReconciliationMode};
+
+/// Version tag for the canonical effect encoding.
+///
+/// Any change to how effects are normalized, ordered, or bound must introduce
+/// a new constant. Digests computed under different encodings are never
+/// comparable, so a pending approval computed under an older encoding is
+/// superseded rather than silently accepted.
+pub const APPROVAL_EFFECT_ENCODING_V1: &str = "pgroles.io/approval-effect/v1";
+
+/// Refusal to produce a digest that would not bind what it claims to bind.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ApprovalDigestError {
+    /// A `SetPassword` change was present without a corresponding password
+    /// source version.
+    ///
+    /// Binding the role alone would let an approval for one password source
+    /// carry over to a different one, so this fails closed instead.
+    #[error(
+        "no password source version recorded for role `{role}`: \
+         refusing to compute an approval digest that cannot bind the password source"
+    )]
+    MissingPasswordSource { role: String },
+}
+
+/// Context bound into the digest alongside the effects themselves.
+#[derive(Debug, Clone, Copy)]
+pub struct EffectDigestInputs<'a> {
+    /// How the desired state converges. The same effects under a different
+    /// mode are a different approval.
+    pub reconciliation_mode: ReconciliationMode,
+    /// Identity of the database the effects were computed against.
+    pub target: &'a str,
+    /// Stable password source identity per role, keyed by role name — for the
+    /// operator this is `secret:key:resourceVersion`. Every role named by a
+    /// `SetPassword` change must have an entry.
+    pub password_source_versions: &'a BTreeMap<String, String>,
+}
+
+#[derive(Serialize)]
+struct CanonicalChangeSet<'a> {
+    effect_encoding: &'a str,
+    reconciliation_mode: ReconciliationMode,
+    target: &'a str,
+    effects: Vec<Value>,
+}
+
+/// Compute the canonical approval-effect digest for a set of changes.
+///
+/// The result is stable across recomputation of the same semantic effects and
+/// independent of the order the diff engine emitted them in.
+pub fn compute_change_digest(
+    changes: &[Change],
+    inputs: &EffectDigestInputs<'_>,
+) -> Result<String, ApprovalDigestError> {
+    let mut effects = Vec::with_capacity(changes.len());
+    for change in changes {
+        effects.push(canonical_effect(change, inputs.password_source_versions)?);
+    }
+
+    // Dependency ordering is an execution concern; two plans with the same set
+    // of effects are the same approval regardless of emission order.
+    effects.sort_by_cached_key(ToString::to_string);
+
+    let bytes = serde_json::to_vec(&CanonicalChangeSet {
+        effect_encoding: APPROVAL_EFFECT_ENCODING_V1,
+        reconciliation_mode: inputs.reconciliation_mode,
+        target: inputs.target,
+        effects,
+    })
+    .expect("canonical change set is serializable");
+
+    Ok(sha256_prefixed(&bytes))
+}
+
+/// Project one change onto its canonical, stable form.
+fn canonical_effect(
+    change: &Change,
+    password_source_versions: &BTreeMap<String, String>,
+) -> Result<Value, ApprovalDigestError> {
+    if let Change::SetPassword { name, .. } = change {
+        let source = password_source_versions
+            .get(name)
+            .ok_or_else(|| ApprovalDigestError::MissingPasswordSource { role: name.clone() })?;
+
+        // The verifier is replaced by the source it was derived from: the same
+        // source always yields the same effect, a rotated source never does.
+        return Ok(serde_json::json!({
+            "SetPassword": {
+                "name": name,
+                "password_source": source,
+            }
+        }));
+    }
+
+    Ok(serde_json::to_value(change).expect("change is serializable"))
+}
+
+fn sha256_prefixed(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+
+    let digest = Sha256::digest(bytes);
+    let mut hash = String::with_capacity(7 + digest.len() * 2);
+    hash.push_str("sha256:");
+    for byte in digest {
+        write!(&mut hash, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{ObjectType, Privilege};
+    use crate::model::RoleState;
+
+    fn versions(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(role, version)| ((*role).to_string(), (*version).to_string()))
+            .collect()
+    }
+
+    fn inputs<'a>(
+        password_source_versions: &'a BTreeMap<String, String>,
+    ) -> EffectDigestInputs<'a> {
+        EffectDigestInputs {
+            reconciliation_mode: ReconciliationMode::Authoritative,
+            target: "default/postgres-credentials:url",
+            password_source_versions,
+        }
+    }
+
+    fn set_password(name: &str, verifier: &str) -> Change {
+        Change::SetPassword {
+            name: name.to_string(),
+            password: verifier.to_string(),
+        }
+    }
+
+    fn create_role(name: &str) -> Change {
+        Change::CreateRole {
+            name: name.to_string(),
+            state: RoleState {
+                login: true,
+                ..RoleState::default()
+            },
+        }
+    }
+
+    fn grant(role: &str) -> Change {
+        Change::Grant {
+            role: role.to_string(),
+            privileges: [Privilege::Select].into_iter().collect(),
+            object_type: ObjectType::Table,
+            schema: Some("inventory".to_string()),
+            name: Some("orders".to_string()),
+        }
+    }
+
+    /// The regression that motivates this module (#174): a fresh SCRAM salt on
+    /// every diff must not change the approval identity.
+    #[test]
+    fn password_verifier_does_not_affect_the_digest() {
+        let versions = versions(&[("app", "role-passwords:app:7")]);
+        let inputs = inputs(&versions);
+
+        let first = compute_change_digest(
+            &[set_password(
+                "app",
+                "SCRAM-SHA-256$4096:saltA$storedA:serverA",
+            )],
+            &inputs,
+        )
+        .expect("digest");
+        let second = compute_change_digest(
+            &[set_password(
+                "app",
+                "SCRAM-SHA-256$4096:saltB$storedB:serverB",
+            )],
+            &inputs,
+        )
+        .expect("digest");
+
+        assert_eq!(
+            first, second,
+            "a re-derived verifier for an unchanged source must keep the same approval identity"
+        );
+    }
+
+    #[test]
+    fn rotating_the_password_source_changes_the_digest() {
+        let before = versions(&[("app", "role-passwords:app:7")]);
+        let after = versions(&[("app", "role-passwords:app:8")]);
+        let change = [set_password("app", "SCRAM-SHA-256$4096:salt$stored:server")];
+
+        assert_ne!(
+            compute_change_digest(&change, &inputs(&before)).expect("digest"),
+            compute_change_digest(&change, &inputs(&after)).expect("digest"),
+            "an approval must not carry over to a different password source"
+        );
+    }
+
+    #[test]
+    fn a_password_change_without_a_source_version_fails_closed() {
+        let empty = BTreeMap::new();
+
+        assert_eq!(
+            compute_change_digest(&[set_password("app", "SCRAM-SHA-256$...")], &inputs(&empty)),
+            Err(ApprovalDigestError::MissingPasswordSource {
+                role: "app".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn emission_order_does_not_affect_the_digest() {
+        let versions = BTreeMap::new();
+        let inputs = inputs(&versions);
+        let forward = [create_role("reporting"), grant("reporting")];
+        let reversed = [grant("reporting"), create_role("reporting")];
+
+        assert_eq!(
+            compute_change_digest(&forward, &inputs).expect("digest"),
+            compute_change_digest(&reversed, &inputs).expect("digest"),
+        );
+    }
+
+    #[test]
+    fn effects_are_bound_to_the_reconciliation_mode() {
+        let versions = BTreeMap::new();
+        let changes = [grant("reporting")];
+
+        let authoritative = compute_change_digest(&changes, &inputs(&versions)).expect("digest");
+        let additive = compute_change_digest(
+            &changes,
+            &EffectDigestInputs {
+                reconciliation_mode: ReconciliationMode::Additive,
+                ..inputs(&versions)
+            },
+        )
+        .expect("digest");
+
+        assert_ne!(authoritative, additive);
+    }
+
+    #[test]
+    fn effects_are_bound_to_the_target() {
+        let versions = BTreeMap::new();
+        let changes = [grant("reporting")];
+
+        let original = compute_change_digest(&changes, &inputs(&versions)).expect("digest");
+        let repointed = compute_change_digest(
+            &changes,
+            &EffectDigestInputs {
+                target: "default/other-credentials:url",
+                ..inputs(&versions)
+            },
+        )
+        .expect("digest");
+
+        assert_ne!(
+            original, repointed,
+            "an approval must not carry over to a different database"
+        );
+    }
+
+    #[test]
+    fn different_effects_produce_different_digests() {
+        let versions = BTreeMap::new();
+        let inputs = inputs(&versions);
+
+        assert_ne!(
+            compute_change_digest(&[grant("reporting")], &inputs).expect("digest"),
+            compute_change_digest(&[grant("analytics")], &inputs).expect("digest"),
+        );
+    }
+
+    #[test]
+    fn an_empty_change_set_has_a_stable_digest() {
+        let versions = BTreeMap::new();
+        let inputs = inputs(&versions);
+
+        assert_eq!(
+            compute_change_digest(&[], &inputs).expect("digest"),
+            compute_change_digest(&[], &inputs).expect("digest"),
+        );
+    }
+
+    #[test]
+    fn the_digest_is_prefixed_and_hex_encoded() {
+        let versions = BTreeMap::new();
+        let digest =
+            compute_change_digest(&[grant("reporting")], &inputs(&versions)).expect("digest");
+
+        let hex = digest.strip_prefix("sha256:").expect("sha256: prefix");
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn the_digest_never_contains_password_material() {
+        let versions = versions(&[("app", "role-passwords:app:7")]);
+        let verifier = "SCRAM-SHA-256$4096:c2FsdA==$c3RvcmVk:c2VydmVy";
+
+        // The canonical form is what gets hashed; assert on it directly so a
+        // future refactor cannot quietly reintroduce the verifier.
+        let effect = canonical_effect(&set_password("app", verifier), &versions).expect("effect");
+        let rendered = effect.to_string();
+
+        assert!(!rendered.contains(verifier));
+        assert!(!rendered.contains("SCRAM-SHA-256"));
+        assert!(rendered.contains("role-passwords:app:7"));
+    }
+}

--- a/crates/pgroles-core/src/approval.rs
+++ b/crates/pgroles-core/src/approval.rs
@@ -91,6 +91,22 @@ pub fn compute_change_digest(
     changes: &[Change],
     inputs: &EffectDigestInputs<'_>,
 ) -> Result<String, ApprovalDigestError> {
+    Ok(sha256_prefixed(&canonical_change_set_bytes(
+        changes, inputs,
+    )?))
+}
+
+/// The exact bytes [`compute_change_digest`] hashes.
+///
+/// Exposed for two reasons: diagnosing *why* two digests differ without
+/// re-deriving the encoding by hand, and letting tests assert on what actually
+/// enters the hash. Asserting on the digest alone cannot show that password
+/// material was excluded — a hash never contains its input literally, so such
+/// a check passes whether or not the exclusion works.
+pub fn canonical_change_set_bytes(
+    changes: &[Change],
+    inputs: &EffectDigestInputs<'_>,
+) -> Result<Vec<u8>, ApprovalDigestError> {
     let mut effects = Vec::with_capacity(changes.len());
     for change in changes {
         effects.push(canonical_effect(change, inputs.password_source_versions)?);
@@ -100,15 +116,13 @@ pub fn compute_change_digest(
     // of effects are the same approval regardless of emission order.
     effects.sort_by_cached_key(ToString::to_string);
 
-    let bytes = serde_json::to_vec(&CanonicalChangeSet {
+    Ok(serde_json::to_vec(&CanonicalChangeSet {
         effect_encoding: APPROVAL_EFFECT_ENCODING_V1,
         reconciliation_mode: inputs.reconciliation_mode,
         target: inputs.target,
         effects,
     })
-    .expect("canonical change set is serializable");
-
-    Ok(sha256_prefixed(&bytes))
+    .expect("canonical change set is serializable"))
 }
 
 /// Project one change onto its canonical, stable form.

--- a/crates/pgroles-core/src/lib.rs
+++ b/crates/pgroles-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod approval;
 pub mod composition;
 pub mod diff;
 pub mod export;

--- a/crates/pgroles-core/tests/approval_property.rs
+++ b/crates/pgroles-core/tests/approval_property.rs
@@ -1,0 +1,469 @@
+//! Property tests for the canonical approval-effect digest
+//! (`pgroles_core::approval`).
+//!
+//! The digest is an *approval gate* for SQL executed against production
+//! databases, so its contract is adversarial rather than merely functional:
+//!
+//! - **stable** where it must be — recomputation of unchanged effects yields
+//!   the same digest, including when the rendered SQL would differ (#174)
+//! - **sensitive** where it must be — any change to the effects, the password
+//!   source, the reconciliation mode, or the target database changes it
+//! - **injective in practice** — distinct effect sets do not collide, because
+//!   a collision would let an approval for one change authorise another
+//!
+//! Unit tests in `src/approval.rs` pin these on hand-written examples. This
+//! suite checks them across a large pseudo-random space of change sets, which
+//! is where an encoding mistake (a field omitted from serialization, two
+//! variants flattening to the same shape) would actually show up.
+//!
+//! Following `diff_property.rs`, this uses a tiny seeded xorshift64* PRNG so
+//! runs are reproducible with no extra dependencies; failures print the seed.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use pgroles_core::approval::{
+    EffectDigestInputs, canonical_change_set_bytes, compute_change_digest,
+};
+use pgroles_core::diff::{Change, ReconciliationMode};
+use pgroles_core::manifest::{ObjectType, Privilege};
+use pgroles_core::model::{RoleAttribute, RoleState};
+
+const CASES: usize = 400;
+
+// ---------------------------------------------------------------------------
+// PRNG (same shape as diff_property.rs)
+// ---------------------------------------------------------------------------
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(if seed == 0 {
+            0x9E37_79B9_7F4A_7C15
+        } else {
+            seed
+        })
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    fn usize(&mut self, modulus: usize) -> usize {
+        if modulus == 0 {
+            return 0;
+        }
+        (self.next_u64() as usize) % modulus
+    }
+    fn bool(&mut self) -> bool {
+        self.next_u64() & 1 == 1
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generators
+// ---------------------------------------------------------------------------
+
+const ROLES: &[&str] = &["app", "reporting", "analytics", "owner", "legacy"];
+const SCHEMAS: &[&str] = &["public", "inventory", "catalog"];
+const OBJECTS: &[&str] = &["orders", "customers", "*"];
+
+fn role(rng: &mut Rng) -> String {
+    ROLES[rng.usize(ROLES.len())].to_string()
+}
+
+fn privileges(rng: &mut Rng) -> BTreeSet<Privilege> {
+    const ALL: &[Privilege] = &[
+        Privilege::Select,
+        Privilege::Insert,
+        Privilege::Update,
+        Privilege::Delete,
+        Privilege::Usage,
+        Privilege::Execute,
+        Privilege::Create,
+        Privilege::Connect,
+    ];
+    let count = 1 + rng.usize(3);
+    (0..count).map(|_| ALL[rng.usize(ALL.len())]).collect()
+}
+
+fn object_type(rng: &mut Rng) -> ObjectType {
+    const ALL: &[ObjectType] = &[
+        ObjectType::Table,
+        ObjectType::View,
+        ObjectType::MaterializedView,
+        ObjectType::Sequence,
+        ObjectType::Function,
+        ObjectType::Schema,
+    ];
+    ALL[rng.usize(ALL.len())]
+}
+
+/// One arbitrary change. Covers every variant that carries semantics an
+/// approval must bind.
+fn change(rng: &mut Rng) -> Change {
+    match rng.usize(14) {
+        0 => Change::CreateRole {
+            name: role(rng),
+            state: RoleState {
+                login: rng.bool(),
+                superuser: rng.bool(),
+                createdb: rng.bool(),
+                connection_limit: rng.usize(4) as i32 - 1,
+                comment: if rng.bool() {
+                    Some("managed".to_string())
+                } else {
+                    None
+                },
+                ..RoleState::default()
+            },
+        },
+        1 => Change::CreateSchema {
+            name: SCHEMAS[rng.usize(SCHEMAS.len())].to_string(),
+            owner: if rng.bool() { Some(role(rng)) } else { None },
+        },
+        2 => Change::AlterSchemaOwner {
+            name: SCHEMAS[rng.usize(SCHEMAS.len())].to_string(),
+            owner: role(rng),
+        },
+        3 => Change::AlterRole {
+            name: role(rng),
+            attributes: vec![
+                RoleAttribute::Login(rng.bool()),
+                RoleAttribute::ConnectionLimit(rng.usize(8) as i32 - 1),
+            ],
+        },
+        4 => Change::SetComment {
+            name: role(rng),
+            comment: if rng.bool() {
+                Some(format!("note-{}", rng.usize(4)))
+            } else {
+                None
+            },
+        },
+        5 => Change::Grant {
+            role: role(rng),
+            privileges: privileges(rng),
+            object_type: object_type(rng),
+            schema: Some(SCHEMAS[rng.usize(SCHEMAS.len())].to_string()),
+            name: Some(OBJECTS[rng.usize(OBJECTS.len())].to_string()),
+        },
+        6 => Change::Revoke {
+            role: role(rng),
+            privileges: privileges(rng),
+            object_type: object_type(rng),
+            schema: Some(SCHEMAS[rng.usize(SCHEMAS.len())].to_string()),
+            name: Some(OBJECTS[rng.usize(OBJECTS.len())].to_string()),
+        },
+        7 => Change::SetDefaultPrivilege {
+            owner: role(rng),
+            schema: SCHEMAS[rng.usize(SCHEMAS.len())].to_string(),
+            on_type: object_type(rng),
+            grantee: role(rng),
+            privileges: privileges(rng),
+        },
+        8 => Change::RevokeDefaultPrivilege {
+            owner: role(rng),
+            schema: SCHEMAS[rng.usize(SCHEMAS.len())].to_string(),
+            on_type: object_type(rng),
+            grantee: role(rng),
+            privileges: privileges(rng),
+        },
+        9 => Change::AddMember {
+            role: role(rng),
+            member: role(rng),
+            inherit: rng.bool(),
+            admin: rng.bool(),
+        },
+        10 => Change::RemoveMember {
+            role: role(rng),
+            member: role(rng),
+        },
+        11 => Change::ReassignOwned {
+            from_role: role(rng),
+            to_role: role(rng),
+        },
+        12 => Change::DropRole { name: role(rng) },
+        _ => Change::SetPassword {
+            name: role(rng),
+            // Stands in for a freshly salted SCRAM verifier.
+            password: format!("SCRAM-SHA-256$4096:salt{}$stored:server", rng.next_u64()),
+        },
+    }
+}
+
+fn change_set(rng: &mut Rng) -> Vec<Change> {
+    let count = rng.usize(8);
+    (0..count).map(|_| change(rng)).collect()
+}
+
+/// Every role gets a source version, so any generated `SetPassword` is bound.
+fn all_password_versions(tag: &str) -> BTreeMap<String, String> {
+    ROLES
+        .iter()
+        .map(|r| ((*r).to_string(), format!("role-passwords:{r}:{tag}")))
+        .collect()
+}
+
+fn digest(changes: &[Change], versions: &BTreeMap<String, String>) -> String {
+    compute_change_digest(
+        changes,
+        &EffectDigestInputs {
+            reconciliation_mode: ReconciliationMode::Authoritative,
+            target: "default/postgres-credentials:url",
+            password_source_versions: versions,
+        },
+    )
+    .expect("every generated role has a password source version")
+}
+
+/// Re-derive every password verifier, as a fresh reconcile would.
+fn resalt(changes: &[Change], rng: &mut Rng) -> Vec<Change> {
+    changes
+        .iter()
+        .map(|c| match c {
+            Change::SetPassword { name, .. } => Change::SetPassword {
+                name: name.clone(),
+                password: format!("SCRAM-SHA-256$4096:salt{}$stored:server", rng.next_u64()),
+            },
+            other => other.clone(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+/// Recomputing the same effects yields the same digest — including when every
+/// SCRAM verifier is re-derived. This is #174 as a property: an unchanged
+/// password source must not churn the approval identity.
+#[test]
+fn digest_is_stable_under_verifier_rederivation() {
+    let versions = all_password_versions("7");
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        let resalted = resalt(&changes, &mut rng);
+
+        assert_eq!(
+            digest(&changes, &versions),
+            digest(&resalted, &versions),
+            "seed {seed}: re-deriving verifiers changed the approval identity"
+        );
+    }
+}
+
+/// The digest does not depend on the order the diff engine emitted changes in.
+#[test]
+fn digest_is_independent_of_emission_order() {
+    let versions = all_password_versions("7");
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        if changes.len() < 2 {
+            continue;
+        }
+
+        let mut shuffled = changes.clone();
+        for i in (1..shuffled.len()).rev() {
+            shuffled.swap(i, rng.usize(i + 1));
+        }
+
+        assert_eq!(
+            digest(&changes, &versions),
+            digest(&shuffled, &versions),
+            "seed {seed}: reordering identical effects changed the digest"
+        );
+    }
+}
+
+/// Distinct effect sets must not collide: a collision would let an approval
+/// for one change set authorise a different one.
+#[test]
+fn distinct_effect_sets_do_not_collide() {
+    let versions = all_password_versions("7");
+    let mut seen: BTreeMap<String, Vec<Change>> = BTreeMap::new();
+
+    for seed in 1..=(CASES * 4) as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        let d = digest(&changes, &versions);
+
+        // Canonicalise for comparison the same way the digest does — as a
+        // multiset of effects, with password verifiers reduced to the role
+        // they act on (the verifier is deliberately not part of identity).
+        let key = canonical_key(&changes);
+
+        if let Some(previous) = seen.get(&d) {
+            assert_eq!(
+                canonical_key(previous),
+                key,
+                "seed {seed}: two different effect sets produced the same digest {d}"
+            );
+        } else {
+            seen.insert(d, changes);
+        }
+    }
+}
+
+/// Rotating any password source changes the digest, so an approval never
+/// carries across a credential rotation.
+#[test]
+fn rotating_a_password_source_changes_the_digest() {
+    let before = all_password_versions("7");
+    let after = all_password_versions("8");
+
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        if !changes
+            .iter()
+            .any(|c| matches!(c, Change::SetPassword { .. }))
+        {
+            continue;
+        }
+
+        assert_ne!(
+            digest(&changes, &before),
+            digest(&changes, &after),
+            "seed {seed}: an approval survived a password source rotation"
+        );
+    }
+}
+
+/// The reconciliation mode and the target database are part of the identity:
+/// the same effects under a different mode, or against a different server,
+/// are a different approval.
+#[test]
+fn digest_binds_mode_and_target() {
+    let versions = all_password_versions("7");
+
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        if changes.is_empty() {
+            continue;
+        }
+
+        let base = digest(&changes, &versions);
+
+        let other_mode = compute_change_digest(
+            &changes,
+            &EffectDigestInputs {
+                reconciliation_mode: ReconciliationMode::Additive,
+                target: "default/postgres-credentials:url",
+                password_source_versions: &versions,
+            },
+        )
+        .expect("digest");
+
+        let other_target = compute_change_digest(
+            &changes,
+            &EffectDigestInputs {
+                reconciliation_mode: ReconciliationMode::Authoritative,
+                target: "default/other-credentials:url",
+                password_source_versions: &versions,
+            },
+        )
+        .expect("digest");
+
+        assert_ne!(base, other_mode, "seed {seed}: mode not bound into digest");
+        assert_ne!(
+            base, other_target,
+            "seed {seed}: target not bound into digest"
+        );
+    }
+}
+
+/// Adding or removing any single effect changes the digest.
+#[test]
+fn every_effect_contributes_to_the_digest() {
+    let versions = all_password_versions("7");
+
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let changes = change_set(&mut rng);
+        if changes.is_empty() {
+            continue;
+        }
+
+        let full = digest(&changes, &versions);
+        let dropped_index = rng.usize(changes.len());
+        let mut reduced = changes.clone();
+        let removed = reduced.remove(dropped_index);
+
+        // Removing a duplicate leaves the multiset otherwise intact only when
+        // no identical effect remains; skip those cases rather than assert a
+        // property the encoding does not claim.
+        if reduced.contains(&removed) {
+            continue;
+        }
+
+        assert_ne!(
+            full,
+            digest(&reduced, &versions),
+            "seed {seed}: dropping an effect left the digest unchanged"
+        );
+    }
+}
+
+/// No password material may reach the bytes that are hashed.
+///
+/// This asserts on the canonical bytes rather than the digest: a hash never
+/// contains its input literally, so checking the digest string would pass even
+/// if the verifier were being hashed in.
+#[test]
+fn password_material_never_reaches_the_hashed_bytes() {
+    let versions = all_password_versions("7");
+
+    for seed in 1..=CASES as u64 {
+        let mut rng = Rng::new(seed);
+        let secret = format!("SUPERSECRET{}", rng.next_u64());
+        let mut changes = change_set(&mut rng);
+        changes.push(Change::SetPassword {
+            name: role(&mut rng),
+            password: secret.clone(),
+        });
+
+        let bytes = canonical_change_set_bytes(
+            &changes,
+            &EffectDigestInputs {
+                reconciliation_mode: ReconciliationMode::Authoritative,
+                target: "default/postgres-credentials:url",
+                password_source_versions: &versions,
+            },
+        )
+        .expect("digest inputs");
+        let encoded = String::from_utf8(bytes).expect("canonical bytes are UTF-8 JSON");
+
+        assert!(
+            !encoded.contains(&secret),
+            "seed {seed}: password material entered the hashed bytes"
+        );
+        assert!(
+            !encoded.contains("SCRAM-SHA-256"),
+            "seed {seed}: a SCRAM verifier entered the hashed bytes"
+        );
+        assert!(
+            digest(&changes, &versions).starts_with("sha256:"),
+            "seed {seed}: malformed digest"
+        );
+    }
+}
+
+/// Reduce a change set to what the digest treats as its identity.
+fn canonical_key(changes: &[Change]) -> Vec<String> {
+    let mut keys: Vec<String> = changes
+        .iter()
+        .map(|c| match c {
+            Change::SetPassword { name, .. } => format!("SetPassword({name})"),
+            other => format!("{other:?}"),
+        })
+        .collect();
+    keys.sort();
+    keys
+}

--- a/crates/pgroles-core/tests/approval_property.rs
+++ b/crates/pgroles-core/tests/approval_property.rs
@@ -105,7 +105,7 @@ fn object_type(rng: &mut Rng) -> ObjectType {
 /// One arbitrary change. Covers every variant that carries semantics an
 /// approval must bind.
 fn change(rng: &mut Rng) -> Change {
-    match rng.usize(14) {
+    match rng.usize(17) {
         0 => Change::CreateRole {
             name: role(rng),
             state: RoleState {
@@ -187,6 +187,16 @@ fn change(rng: &mut Rng) -> Change {
             to_role: role(rng),
         },
         12 => Change::DropRole { name: role(rng) },
+        // DropOwned and TerminateSessions both carry a single `role` field,
+        // so they are the likeliest pair to flatten to the same encoded shape
+        // — exactly the collision this suite exists to rule out.
+        13 => Change::DropOwned { role: role(rng) },
+        14 => Change::TerminateSessions { role: role(rng) },
+        15 => Change::EnsureSchemaOwnerPrivileges {
+            name: SCHEMAS[rng.usize(SCHEMAS.len())].to_string(),
+            owner: role(rng),
+            privileges: privileges(rng),
+        },
         _ => Change::SetPassword {
             name: role(rng),
             // Stands in for a freshly salted SCRAM verifier.

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1084,7 +1084,7 @@ pub struct PostgresPolicyPlanStatus {
     #[serde(default)]
     pub sql_statements: Option<i64>,
     /// SHA-256 hash of the redacted SQL preview bytes. This is for storage
-    /// integrity only; approval and deduplication continue to use `sql_hash`.
+    /// integrity only; approval and deduplication use `change_digest`.
     #[serde(default)]
     pub redacted_sql_hash: Option<String>,
     /// Uncompressed byte length of the redacted SQL preview.

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1052,11 +1052,26 @@ pub struct PostgresPolicyPlanStatus {
     /// Error message if apply failed.
     #[serde(default)]
     pub last_error: Option<String>,
-    /// SHA-256 hash of the planned SQL, used to detect duplicate plans.
-    /// If a newly computed plan has the same hash as the current pending plan,
-    /// the operator can skip creating a redundant plan.
+    /// SHA-256 hash of the planned SQL. Retained as a diagnostic for the
+    /// preview artifact; it is **not** the approval identity, because rendered
+    /// SQL embeds a freshly salted SCRAM verifier for every password change.
+    /// Use `change_digest` for approval and deduplication.
     #[serde(default)]
     pub sql_hash: Option<String>,
+    /// Canonical semantic digest of the plan's typed effects, bound to the
+    /// reconciliation mode and target database identity.
+    ///
+    /// This is the approval identity: a decision approves these effects, and
+    /// execution proceeds only when the recomputed digest still matches. It is
+    /// stable across recomputation of unchanged effects — notably for password
+    /// changes, which bind the password *source* rather than the derived
+    /// verifier. See `pgroles_core::approval`.
+    #[serde(default)]
+    pub change_digest: Option<String>,
+    /// Version tag of the encoding `change_digest` was computed under. Digests
+    /// from different encodings are never comparable.
+    #[serde(default)]
+    pub change_digest_encoding: Option<String>,
     /// Timestamp when the plan entered Applying phase (for stuck detection).
     #[serde(default)]
     pub applying_since: Option<String>,

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -27,6 +27,7 @@ use crate::crd::{
 };
 use crate::k8s_names::{LabelValue, truncate_name_prefix};
 use crate::reconciler::ReconcileError;
+use pgroles_core::approval::APPROVAL_EFFECT_ENCODING_V1;
 
 /// Result of plan creation — distinguishes genuinely new plans from
 /// deduplication hits so callers can decide whether to emit events.
@@ -191,15 +192,29 @@ pub async fn create_or_update_plan(
     reconciliation_mode: CrdReconciliationMode,
     database_identity: &str,
     change_summary: &ChangeSummary,
+    password_source_versions: &BTreeMap<String, String>,
 ) -> Result<PlanCreationResult, ReconcileError> {
     let namespace = policy.namespace().ok_or(ReconcileError::NoNamespace)?;
     let policy_name = policy.name_any();
     let generation = policy.metadata.generation.unwrap_or(0);
 
-    // 1. Render the full executable SQL (not redacted).
+    // 1. Render the full executable SQL (not redacted). This is a review
+    //    artifact only — never an execution payload, and never the approval
+    //    identity.
     let full_sql = render_full_sql(changes, sql_context);
 
-    // 2. Compute SHA-256 hash of the full SQL.
+    // 2. Compute the approval identity: a canonical digest of the typed
+    //    effects. Deduplication and approval both key off this rather than the
+    //    SQL hash, which is unstable for password changes (fresh SCRAM salt on
+    //    every render).
+    let change_digest = compute_change_digest(
+        changes,
+        reconciliation_mode,
+        database_identity,
+        password_source_versions,
+    )?;
+
+    // 3. Hash the rendered SQL for preview diagnostics.
     let sql_hash = compute_sql_hash(&full_sql);
 
     // 3. Count SQL statements (after wildcard expansion).
@@ -222,18 +237,18 @@ pub async fn create_or_update_plan(
         .filter(|plan| is_owned_by_policy(plan, policy))
         .collect();
 
-    // 5. Check for duplicate pending plan with same hash.
+    // 5. Check for duplicate pending plan with the same effects.
     for plan in &existing_plans {
         if let Some(ref status) = plan.status
             && status.phase == PlanPhase::Pending
-            && status.sql_hash.as_deref() == Some(&sql_hash)
+            && plan_matches_digest(status, &change_digest)
         {
             // Identical plan already exists — return early (deduplicated).
             let plan_name = plan.name_any();
             info!(
                 plan = %plan_name,
                 policy = %policy_name,
-                "existing pending plan has identical SQL hash, skipping creation"
+                "existing pending plan has identical change digest, skipping creation"
             );
             return Ok(PlanCreationResult::Deduplicated(plan_name));
         }
@@ -250,7 +265,7 @@ pub async fn create_or_update_plan(
     for plan in &existing_plans {
         if let Some(ref status) = plan.status
             && status.phase == PlanPhase::Failed
-            && status.sql_hash.as_deref() == Some(&sql_hash)
+            && plan_matches_digest(status, &change_digest)
         {
             let failed_ts = status
                 .failed_at
@@ -263,7 +278,7 @@ pub async fn create_or_update_plan(
                     plan = %plan_name,
                     policy = %policy_name,
                     age_secs = now_ts - failed_ts,
-                    "recently-failed plan has identical SQL hash, skipping creation"
+                    "recently-failed plan has identical change digest, skipping creation"
                 );
                 return Ok(PlanCreationResult::Deduplicated(plan_name));
             }
@@ -415,6 +430,8 @@ pub async fn create_or_update_plan(
         applied_at: None,
         last_error: None,
         sql_hash: Some(sql_hash),
+        change_digest: Some(change_digest),
+        change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
         applying_since: None,
         failed_at: None,
         sql_statements: Some(sql_statement_count),
@@ -1126,6 +1143,42 @@ fn render_redacted_sql(
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Compute the canonical approval-effect digest for a set of changes.
+///
+/// This is the approval identity — see `pgroles_core::approval`. Unlike the
+/// SQL hash it is stable across recomputation of unchanged effects, which is
+/// what makes a password-bearing plan approvable at all.
+pub(crate) fn compute_change_digest(
+    changes: &[pgroles_core::diff::Change],
+    reconciliation_mode: CrdReconciliationMode,
+    database_identity: &str,
+    password_source_versions: &BTreeMap<String, String>,
+) -> Result<String, ReconcileError> {
+    Ok(pgroles_core::approval::compute_change_digest(
+        changes,
+        &pgroles_core::approval::EffectDigestInputs {
+            reconciliation_mode: reconciliation_mode.into(),
+            target: database_identity,
+            password_source_versions,
+        },
+    )?)
+}
+
+/// Whether a stored plan status carries the given change digest under the
+/// current encoding.
+///
+/// Digests from a different encoding version are never comparable, so a plan
+/// written by an earlier operator (no digest, or an older encoding) never
+/// matches. Such plans are superseded and re-reviewed rather than silently
+/// accepted — the fail-closed direction.
+pub(crate) fn plan_matches_digest(
+    status: &crate::crd::PostgresPolicyPlanStatus,
+    change_digest: &str,
+) -> bool {
+    status.change_digest_encoding.as_deref() == Some(APPROVAL_EFFECT_ENCODING_V1)
+        && status.change_digest.as_deref() == Some(change_digest)
 }
 
 /// Compute SHA-256 hash of the SQL string as a hex digest.
@@ -2290,5 +2343,129 @@ mod tests {
         let mut decoded = String::new();
         decoder.read_to_string(&mut decoded).unwrap();
         decoded
+    }
+
+    // -----------------------------------------------------------------------
+    // Approval identity (#174)
+    // -----------------------------------------------------------------------
+
+    fn password_versions(role: &str, version: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([(role.to_string(), version.to_string())])
+    }
+
+    fn set_password(name: &str, verifier: &str) -> pgroles_core::diff::Change {
+        pgroles_core::diff::Change::SetPassword {
+            name: name.to_string(),
+            password: verifier.to_string(),
+        }
+    }
+
+    fn digest_for(
+        changes: &[pgroles_core::diff::Change],
+        versions: &BTreeMap<String, String>,
+    ) -> String {
+        compute_change_digest(
+            changes,
+            CrdReconciliationMode::default(),
+            "default/db-credentials:DATABASE_URL",
+            versions,
+        )
+        .expect("digest")
+    }
+
+    /// The #174 failure mode: a manually approved password plan could never
+    /// execute, because each reconcile re-derived the SCRAM verifier with a
+    /// fresh salt and the approval was bound to the rendered SQL.
+    #[test]
+    fn password_plans_keep_one_approval_identity_across_reconciles() {
+        let versions = password_versions("app", "role-passwords:app:7");
+
+        // Two reconciles of an unchanged password source, each with its own
+        // randomly salted verifier.
+        let first = digest_for(
+            &[set_password("app", "SCRAM-SHA-256$4096:aaa$sA:vA")],
+            &versions,
+        );
+        let second = digest_for(
+            &[set_password("app", "SCRAM-SHA-256$4096:bbb$sB:vB")],
+            &versions,
+        );
+
+        assert_eq!(first, second);
+
+        // The SQL hash is what used to gate approval, and is still unstable —
+        // which is exactly why it is no longer the approval identity.
+        let ctx = pgroles_core::sql::SqlContext::default();
+        assert_ne!(
+            compute_sql_hash(&render_full_sql(
+                &[set_password("app", "SCRAM-SHA-256$4096:aaa$sA:vA")],
+                &ctx
+            )),
+            compute_sql_hash(&render_full_sql(
+                &[set_password("app", "SCRAM-SHA-256$4096:bbb$sB:vB")],
+                &ctx
+            )),
+        );
+    }
+
+    #[test]
+    fn rotating_a_password_source_is_a_new_approval() {
+        let change = [set_password("app", "SCRAM-SHA-256$4096:aaa$sA:vA")];
+
+        assert_ne!(
+            digest_for(&change, &password_versions("app", "role-passwords:app:7")),
+            digest_for(&change, &password_versions("app", "role-passwords:app:8")),
+        );
+    }
+
+    #[test]
+    fn a_plan_matches_only_its_own_digest_under_the_current_encoding() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let digest = digest_for(
+            &[set_password("app", "SCRAM-SHA-256$4096:aaa$sA:vA")],
+            &versions,
+        );
+
+        let current = PostgresPolicyPlanStatus {
+            change_digest: Some(digest.clone()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        assert!(plan_matches_digest(&current, &digest));
+
+        // A plan written before this encoding existed must never match, so it
+        // is superseded and re-reviewed rather than silently accepted.
+        let legacy = PostgresPolicyPlanStatus {
+            sql_hash: Some("deadbeef".to_string()),
+            ..Default::default()
+        };
+        assert!(!plan_matches_digest(&legacy, &digest));
+
+        let other_encoding = PostgresPolicyPlanStatus {
+            change_digest: Some(digest.clone()),
+            change_digest_encoding: Some("pgroles.io/approval-effect/v0".to_string()),
+            ..Default::default()
+        };
+        assert!(!plan_matches_digest(&other_encoding, &digest));
+
+        let different_effects = PostgresPolicyPlanStatus {
+            change_digest: Some("sha256:0000".to_string()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        assert!(!plan_matches_digest(&different_effects, &digest));
+    }
+
+    /// Planning must never persist password material, in any field.
+    #[test]
+    fn the_digest_carries_no_password_material() {
+        let verifier = "SCRAM-SHA-256$4096:c2FsdA==$c3RvcmVk:c2VydmVy";
+        let digest = digest_for(
+            &[set_password("app", verifier)],
+            &password_versions("app", "role-passwords:app:7"),
+        );
+
+        assert!(digest.starts_with("sha256:"));
+        assert!(!digest.contains(verifier));
     }
 }

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -217,10 +217,10 @@ pub async fn create_or_update_plan(
     // 3. Hash the rendered SQL for preview diagnostics.
     let sql_hash = compute_sql_hash(&full_sql);
 
-    // 3. Count SQL statements (after wildcard expansion).
+    // 4. Count SQL statements (after wildcard expansion).
     let sql_statement_count = full_sql.lines().filter(|l| !l.trim().is_empty()).count() as i64;
 
-    // 4. Render redacted SQL for display (passwords masked).
+    // 5. Render redacted SQL for display (passwords masked).
     let redacted_sql = render_redacted_sql(changes, sql_context);
 
     cleanup_old_plans_best_effort(client, policy, None).await;
@@ -254,10 +254,11 @@ pub async fn create_or_update_plan(
         }
     }
 
-    // 5b. Check for recently-failed plan with the same hash. If a plan with
-    // this exact SQL already failed within the dedup window, creating another
-    // identical one is pointless — it would produce the same error. The window
-    // ensures we don't block retries after the user fixes the environment.
+    // 5b. Check for a recently-failed plan with the same change digest. If a
+    // plan with these exact effects already failed within the dedup window,
+    // creating another identical one is pointless — it would produce the same
+    // error. The window ensures we don't block retries after the user fixes
+    // the environment.
     //
     // Uses `status.failed_at` (not `creation_timestamp`) so that plans which
     // waited for approval before failing are measured from the failure time.

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -134,6 +134,9 @@ pub enum ReconcileError {
     #[error("invalid spec: {0}")]
     InvalidSpec(String),
 
+    #[error("approval digest error: {0}")]
+    ApprovalDigest(#[from] pgroles_core::approval::ApprovalDigestError),
+
     #[error(
         "policy references objects that do not exist in target database: {0}. Either create \
          the missing objects, remove them from the policy, or verify the policy is pointing at \
@@ -384,6 +387,7 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
         | ReconcileError::UnsafeRoleDrops(_)
         | ReconcileError::EmptyPasswordSecret { .. }
         | ReconcileError::NoNamespace
+        | ReconcileError::ApprovalDigest(_)
         | ReconcileError::PlanSqlStorage(_) => RetryClass::Slow,
         ReconcileError::PasswordGeneration(err) => {
             if err.is_transient() {
@@ -1082,6 +1086,7 @@ async fn apply_under_lock(
                 resource.spec.reconciliation_mode,
                 identity.as_str(),
                 &summary,
+                &applied_password_source_versions,
             )
             .await?;
             let plan_name = creation_result.plan_name().to_string();
@@ -1186,6 +1191,7 @@ async fn apply_under_lock(
                     resource.spec.reconciliation_mode,
                     identity.as_str(),
                     &summary,
+                    &applied_password_source_versions,
                 )
                 .await?;
                 let plan_name = creation_result.plan_name().to_string();
@@ -1292,22 +1298,33 @@ async fn apply_under_lock(
 
                 match approval_state {
                     crate::plan::PlanApprovalState::Approved => {
-                        // Validate that the database state has not drifted since
-                        // the plan was approved by comparing SQL hashes.
-                        let fresh_sql = crate::plan::render_full_sql(&changes, &sql_ctx);
-                        let fresh_hash = crate::plan::compute_sql_hash(&fresh_sql);
-                        let stored_hash = current_plan
-                            .status
-                            .as_ref()
-                            .and_then(|s| s.sql_hash.as_deref());
+                        // Validate that nothing the approval bound has changed
+                        // since the decision, by recomputing the canonical
+                        // effect digest. Comparing rendered SQL here would
+                        // supersede every password-bearing plan, because the
+                        // SCRAM verifier is re-salted on each computation.
+                        let fresh_digest = crate::plan::compute_change_digest(
+                            &changes,
+                            resource.spec.reconciliation_mode,
+                            identity.as_str(),
+                            &applied_password_source_versions,
+                        )?;
+                        let digest_matches = current_plan.status.as_ref().is_some_and(|status| {
+                            crate::plan::plan_matches_digest(status, &fresh_digest)
+                        });
 
-                        if stored_hash != Some(&fresh_hash) {
-                            // Database state changed since the plan was approved.
+                        if !digest_matches {
+                            // The approved effects are no longer the effects
+                            // this policy would produce.
+                            let stored_digest = current_plan
+                                .status
+                                .as_ref()
+                                .and_then(|s| s.change_digest.as_deref());
                             tracing::warn!(
                                 plan = %current_plan.name_any(),
-                                stored_hash = ?stored_hash,
-                                fresh_hash = %fresh_hash,
-                                "approved plan superseded: database state changed since approval"
+                                stored_digest = ?stored_digest,
+                                fresh_digest = %fresh_digest,
+                                "approved plan superseded: effects changed since approval"
                             );
 
                             crate::plan::mark_plan_superseded(&ctx.kube_client, &current_plan)
@@ -1323,6 +1340,7 @@ async fn apply_under_lock(
                                 resource.spec.reconciliation_mode,
                                 identity.as_str(),
                                 &summary,
+                                &applied_password_source_versions,
                             )
                             .await?;
                             let new_plan_name = new_creation_result.plan_name().to_string();
@@ -1593,6 +1611,7 @@ async fn apply_under_lock(
                 resource.spec.reconciliation_mode,
                 identity.as_str(),
                 &summary,
+                &applied_password_source_versions,
             )
             .await?;
             let plan_name = creation_result.plan_name().to_string();
@@ -2207,6 +2226,7 @@ impl ReconcileError {
             ReconcileError::ManifestExpansion(_)
             | ReconcileError::InvalidInterval(_, _)
             | ReconcileError::InvalidSpec(_) => "InvalidSpec",
+            ReconcileError::ApprovalDigest(_) => "ApprovalDigestFailed",
             ReconcileError::ConflictingPolicy(_) => "ConflictingPolicy",
             ReconcileError::UnsatisfiableWildcardGrant(_) => "UnsatisfiableWildcardGrant",
             ReconcileError::LockContention(_, _) => "LockContention",

--- a/docs/src/pages/docs/operator-plan-approval.md
+++ b/docs/src/pages/docs/operator-plan-approval.md
@@ -101,8 +101,9 @@ operator.
 What a decision approves is the plan's **change digest**: a versioned hash
 (`pgroles.io/approval-effect/v1`) of the canonical, deterministically ordered
 typed effects — role lifecycle, grants, memberships, ownership and default
-privileges, retirements — bound together with the reconciliation mode, the
-managed scope, and the target identity.
+privileges, retirements — bound together with the reconciliation mode and the
+target identity. (Managed scope joins the binding once it becomes a
+first-class field; today a scope change shows up as a change in effects.)
 
 The applied base is deliberately *not* a digest input. The plan records which
 base it was computed against as provenance, and that record advances whenever

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -193,6 +193,16 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "changeDigest": {
+                    "description": "Canonical semantic digest of the plan's typed effects, bound to the\nreconciliation mode and target database identity.\n\nThis is the approval identity: a decision approves these effects, and\nexecution proceeds only when the recomputed digest still matches. It is\nstable across recomputation of unchanged effects — notably for password\nchanges, which bind the password *source* rather than the derived\nverifier. See `pgroles_core::approval`.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "changeDigestEncoding": {
+                    "description": "Version tag of the encoding `change_digest` was computed under. Digests\nfrom different encodings are never comparable.",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "changeSummary": {
                     "description": "Summary of changes in this plan.",
                     "nullable": true,
@@ -343,7 +353,7 @@
                     "type": "string"
                   },
                   "sqlHash": {
-                    "description": "SHA-256 hash of the planned SQL, used to detect duplicate plans.\nIf a newly computed plan has the same hash as the current pending plan,\nthe operator can skip creating a redundant plan.",
+                    "description": "SHA-256 hash of the planned SQL. Retained as a diagnostic for the\npreview artifact; it is **not** the approval identity, because rendered\nSQL embeds a freshly salted SCRAM verifier for every password change.\nUse `change_digest` for approval and deduplication.",
                     "nullable": true,
                     "type": "string"
                   },

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -348,7 +348,7 @@
                     "type": "string"
                   },
                   "redactedSqlHash": {
-                    "description": "SHA-256 hash of the redacted SQL preview bytes. This is for storage\nintegrity only; approval and deduplication continue to use `sql_hash`.",
+                    "description": "SHA-256 hash of the redacted SQL preview bytes. This is for storage\nintegrity only; approval and deduplication use `change_digest`.",
                     "nullable": true,
                     "type": "string"
                   },


### PR DESCRIPTION
Second PR in the #173 stack (now targeting `main` after #176 merged). Implements Phase 0 item 1, and fixes the operator-facing failure mode in #174.

## The problem

Rendered SQL cannot be an approval identity. `SetPassword` embeds a SCRAM-SHA-256 verifier built with a fresh random salt on every computation (`scram.rs` generates 16 random bytes per call), and `sqlHash` covers that text. So approving a password-bearing plan re-rendered a different hash, superseded the reviewed plan, created a replacement — and approving *that* repeated the cycle. Manual approval was effectively unusable for password creation or rotation.

## What changed

**`pgroles-core::approval`** (new) defines the versioned encoding `pgroles.io/approval-effect/v1`:

- every typed `Change`, normalized and sorted independently of the diff engine's dependency ordering — two plans with the same effects are the same approval regardless of emission order
- bound to the reconciliation mode (the same desired state converges differently under `additive`/`adopt`) and the target database identity (an approval must not carry to a different server)
- excludes cleartext passwords, generated material, SCRAM salts and verifiers, and renderer text **by construction**: a password change is bound as `(role, password source identity and version)`, reusing the `secret:key:resourceVersion` identity the reconciler already computes
- follows the discipline the ephemeral bundle hash already uses (named encoding constant, deterministic serialization, self-verifying `sha256:`-prefixed digest); the effect schema itself is necessarily new

**Fails closed**: a `SetPassword` with no recorded source version returns `MissingPasswordSource` rather than a digest that cannot bind what it claims to.

**Operator**: plans gain `changeDigest` + `changeDigestEncoding`. Deduplication (pending and failed-window) and approve-time validation both key off the digest. `sqlHash` is retained and documented as a preview diagnostic.

## Upgrade behaviour, deliberate

Digests from a different encoding are never comparable, so a plan written by an earlier operator — no digest, or a future older encoding — never matches, is superseded, and gets re-reviewed. That is the fail-closed direction: one extra review round on upgrade, rather than accepting an approval whose identity we cannot verify. Worth a changelog note when this ships.

## Verification, in layers

**Unit** (11 in `approval.rs`, 4 in `plan.rs`) — the #174 regression asserts alongside it that `sqlHash` *is* still unstable for the same input, which is why it can no longer gate approval. Plus fail-closed on missing source, encoding-version mismatch, and a byte-level fixture pinning the canonical JSON.

**Property** (7 over pseudo-random change sets, seeded-PRNG convention of `diff_property.rs`) — stability under verifier re-derivation, independence from emission order, collision-freedom, sensitivity to source rotation, mode/target binding, every effect contributing, and no password material in the hashed bytes.

**Model checking** (`correctness/races/PlanApproval.tla`) — #174 is a *liveness* bug, which is why it survived a safety-focused suite. Three configs, each proving a distinct requirement:

| Config | `SqlHashApproval` | `LockDuringApply` | Result |
| --- | --- | --- | --- |
| `PlanApproval.cfg` | FALSE | TRUE | passes |
| `PlanApproval_buggy.cfg` | TRUE | TRUE | `EventuallyApplies` violated — the #174 approve/supersede lasso |
| `PlanApproval_unlocked.cfg` | FALSE | FALSE | `NoStaleExecution` violated — why there must be no unlock window |

Every safety invariant still holds in the `_buggy` configuration: nothing unsafe executes, the workflow simply never converges.

**Mutation-tested**: removing the verifier exclusion, the canonical sort, or the target binding each fails the suite. That check caught one of my own tests lying — `password_material_never_reaches_the_digest` asserted on the digest string, which a hash never contains its input in, so it passed even when the verifier was being hashed. It now asserts on the canonical bytes via `canonical_change_set_bytes`.

## Review findings addressed

- the correctness spec permitted an apply after database drift, and `NoStaleExecution` was a duplicate of `ExecutedWhatWasApproved` that never checked the database — both fixed, with the lock now modelled explicitly and staleness recorded as an apply-time witness
- the property generator omitted `EnsureSchemaOwnerPrivileges`, `DropOwned` and `TerminateSessions`; the latter two share a single `role` field, making them the likeliest collision pair
- canonical bytes pinned against a dependency silently enabling `serde_json/preserve_order`
- stale CRD descriptions regenerated; stale comments in `plan.rs` corrected

## Local verification

`cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `scripts/check-crd-drift.sh`, `scripts/check-helm-docs.sh`, and all three TLC configurations.

## Not in this PR

Phase 0 items 2–5 (pending-plan revalidation, write-once decisions, tiered target identity, plan-neutral password Secrets) are separate PRs. The `target` bound here is the existing logical `DatabaseIdentity`; item 4 strengthens it to `system_identifier` where available, which will change digests once on that upgrade.

Refs #173. **Refs #174** — this fixes the operator-facing failure mode, but that issue also requires E2E coverage for `secretRef` and `generate` under manual approval, and post-approval generated-Secret timing (Phase 0 item 5). Deliberately left open rather than auto-closed.

https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop