### PR TITLE
feat(operator): revalidate pending plans instead of freezing them

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -352,6 +352,17 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "revalidatedAt": {
+                    "description": "When the plan was most recently confirmed current.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "revalidatedGeneration": {
+                    "description": "The policy generation this plan was most recently confirmed current\nagainst.\n\nA pending plan is revalidated on every reconcile. When the policy\nchanges but the resulting effects do not, the plan — and any decision\nrecorded on it — is retained and this advances to the new generation.\nIt is provenance, never approval identity: `change_digest` is what a\ndecision binds.",
+                    "format": "int64",
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "sqlHash": {
                     "description": "SHA-256 hash of the planned SQL. Retained as a diagnostic for the\npreview artifact; it is **not** the approval identity, because rendered\nSQL embeds a freshly salted SCRAM verifier for every password change.\nUse `change_digest` for approval and deduplication.",
                     "nullable": true,

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -25,6 +25,35 @@ Races modeled:
 4. Database drift changes between plan creation and approval
 5. Hash dedup skips identical plans
 
+### `races/PlanRevalidation.tla`
+
+Verifies what must hold while a plan awaits a manual decision, across the
+reconciles that keep happening underneath it:
+
+- what the policy *reports* and what the pending plan *holds* describe the same
+  effects — a reviewer never reads a fresh summary beside a stale plan
+- an approval survives a policy edit that turns out to be effect-neutral
+
+```sh
+./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation.cfg                # passes
+./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation_frozen.cfg         # SummaryMatchesPlan violated
+./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation_generational.cfg   # ApprovalSurvivesEffectNeutralEdits violated
+```
+
+| Config | `RevalidationMode` | Result |
+| --- | --- | --- |
+| `PlanRevalidation.cfg` | `semantic` | passes |
+| `PlanRevalidation_frozen.cfg` | `frozen` | `SummaryMatchesPlan` violated |
+| `PlanRevalidation_generational.cfg` | `generational` | `ApprovalSurvivesEffectNeutralEdits` violated |
+
+The two failing configurations bracket the design. `frozen` is the behaviour
+before this work: the Pending arm returned early without revalidating, so the
+status summary advanced while the plan stood still. `generational` is the
+plausible wrong fix — superseding whenever the policy generation moves — which
+restores the pairing but discards a decision on every effect-neutral edit. That
+is why `policyGeneration` is a revalidation *trigger* and the change digest is
+the *identity*.
+
 ### `races/PlanApproval.tla`
 
 Verifies what an approval actually binds, by separating two things

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -33,11 +33,13 @@ reconciles that keep happening underneath it:
 - what the policy *reports* and what the pending plan *holds* describe the same
   effects — a reviewer never reads a fresh summary beside a stale plan
 - an approval survives a policy edit that turns out to be effect-neutral
+- a plan holding no effects never sits waiting for a decision
 
 ```sh
 ./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation.cfg                # passes
 ./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation_frozen.cfg         # SummaryMatchesPlan violated
 ./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation_generational.cfg   # ApprovalSurvivesEffectNeutralEdits violated
+./run-tlc.sh races/PlanRevalidation.tla races/PlanRevalidation_replace.cfg        # NoEmptyPendingPlan violated
 ```
 
 | Config | `RevalidationMode` | Result |
@@ -45,14 +47,22 @@ reconciles that keep happening underneath it:
 | `PlanRevalidation.cfg` | `semantic` | passes |
 | `PlanRevalidation_frozen.cfg` | `frozen` | `SummaryMatchesPlan` violated |
 | `PlanRevalidation_generational.cfg` | `generational` | `ApprovalSurvivesEffectNeutralEdits` violated |
+| `PlanRevalidation_replace.cfg` | `replace` | `NoEmptyPendingPlan` violated |
 
-The two failing configurations bracket the design. `frozen` is the behaviour
+The three failing configurations bracket the design. `frozen` is the behaviour
 before this work: the Pending arm returned early without revalidating, so the
 status summary advanced while the plan stood still. `generational` is the
 plausible wrong fix — superseding whenever the policy generation moves — which
 restores the pairing but discards a decision on every effect-neutral edit. That
 is why `policyGeneration` is a revalidation *trigger* and the change digest is
 the *identity*.
+
+`replace` is the narrower mistake: revalidate semantically, but always leave a
+replacement plan behind. When an edit does not move the effects but removes
+them, the replacement holds nothing and still blocks on an approval, while the
+policy reports `Drifted=False` beside it. Superseding a pending plan and
+opening a new one are separate decisions, and only the first applies when there
+is nothing left to execute.
 
 ### `races/PlanApproval.tla`
 

--- a/correctness/races/PlanRevalidation.cfg
+++ b/correctness/races/PlanRevalidation.cfg
@@ -1,0 +1,14 @@
+\* RevalidationMode = "semantic" — see PlanRevalidation.tla for what each proves.
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    RevalidationMode = "semantic"
+    MaxEdits = 2
+
+INVARIANT
+    TypeOK
+    SummaryMatchesPlan
+    ApprovalSurvivesEffectNeutralEdits

--- a/correctness/races/PlanRevalidation.tla
+++ b/correctness/races/PlanRevalidation.tla
@@ -82,9 +82,14 @@ TypeOK ==
 
 \* Property 1. A reviewer reading the policy's summary and opening the plan it
 \* points at must see the same change. The frozen strategy breaks this.
+\*
+\* Stated with no guard on summaryEffects. An earlier form exempted
+\* summaryEffects = NoEffects, which excused exactly the worst reading: the
+\* policy reporting no drift while a plan holding real changes waits beside it.
+\* A strategy that clears the summary but keeps the plan pending passed the
+\* whole suite under the guarded form.
 SummaryMatchesPlan ==
-    (planPhase = Pending /\ summaryEffects /= NoEffects) =>
-        summaryEffects = planEffects
+    (planPhase = Pending) => summaryEffects = planEffects
 
 \* Property 2. An effect-neutral policy edit must not discard a decision.
 \* The generational strategy breaks this.

--- a/correctness/races/PlanRevalidation.tla
+++ b/correctness/races/PlanRevalidation.tla
@@ -29,6 +29,10 @@ EXTENDS FiniteSets, Naturals
                      effect-neutral edit throws away a decision. This is why
                      `policyGeneration` is a revalidation *trigger* and the
                      change digest is the *identity*.
+    - "replace"      (PlanRevalidation_replace.cfg) — compares effects, but
+                     always leaves a replacement plan behind. When the effects
+                     did not move but *vanished*, the replacement holds nothing
+                     and still blocks on a decision. Violates property 3.
 
   What is NOT modeled: approval mechanics and execution (PlanApproval.tla),
   crashes and locking (PlanLifecycle.tla).
@@ -41,9 +45,12 @@ CONSTANTS
 NoPlan == "none"
 Pending == "Pending"
 
-\* Distinct semantic effect sets, standing in for change digests.
+\* Distinct semantic effect sets, standing in for change digests. `NoEffects`
+\* is a first-class value here: a policy edit can remove the drift entirely,
+\* and what happens to a pending plan at that moment is property 3 below.
 Effects == {"e1", "e2"}
 NoEffects == "none"
+MaybeEffects == Effects \cup {NoEffects}
 
 VARIABLES
     planPhase,       \* Whether a plan is currently pending review
@@ -62,11 +69,11 @@ vars == <<planPhase, planEffects, planGen, summaryEffects, approved,
 
 TypeOK ==
     /\ planPhase \in {NoPlan, Pending}
-    /\ planEffects \in Effects \cup {NoEffects}
+    /\ planEffects \in MaybeEffects
     /\ planGen \in 0..MaxEdits
-    /\ summaryEffects \in Effects \cup {NoEffects}
+    /\ summaryEffects \in MaybeEffects
     /\ approved \in BOOLEAN
-    /\ dbEffects \in Effects
+    /\ dbEffects \in MaybeEffects
     /\ policyGen \in 0..MaxEdits
     /\ editsLeft \in 0..MaxEdits
     /\ lostApproval \in BOOLEAN
@@ -83,6 +90,12 @@ SummaryMatchesPlan ==
 \* The generational strategy breaks this.
 ApprovalSurvivesEffectNeutralEdits == ~lostApproval
 
+\* Property 3. Nothing to execute means nothing to approve. A pending plan
+\* holding no effects parks the policy on a decision that buys nothing, while
+\* the policy reports no drift beside it. The "replace" strategy breaks this.
+NoEmptyPendingPlan ==
+    (planPhase = Pending) => planEffects /= NoEffects
+
 Init ==
     /\ planPhase = NoPlan
     /\ planEffects = NoEffects
@@ -96,8 +109,11 @@ Init ==
 
 \* --- Actions ---
 
+\* The operator opens a plan only when there is something to execute; with no
+\* changes it reports InSync and creates nothing.
 OperatorCreatesPlan ==
     /\ planPhase = NoPlan
+    /\ dbEffects /= NoEffects
     /\ planPhase' = Pending
     /\ planEffects' = dbEffects
     /\ summaryEffects' = dbEffects
@@ -114,10 +130,11 @@ PolicyEditEffectNeutral ==
     /\ UNCHANGED <<planPhase, planEffects, planGen, summaryEffects, approved,
                     dbEffects, lostApproval>>
 
-\* A policy edit that genuinely changes what would be executed.
+\* A policy edit that genuinely changes what would be executed — including one
+\* that removes the drift altogether, leaving nothing to do.
 PolicyEditEffective ==
     /\ editsLeft > 0
-    /\ \E e \in Effects:
+    /\ \E e \in MaybeEffects:
         /\ e /= dbEffects
         /\ dbEffects' = e
     /\ policyGen' = policyGen + 1
@@ -143,6 +160,16 @@ SupersedeAndReplace ==
     /\ lostApproval' = (lostApproval \/ (approved /\ planEffects = dbEffects))
     /\ UNCHANGED <<planPhase, dbEffects, policyGen, editsLeft>>
 
+\* Drop the pending plan without opening another: there is nothing left to
+\* execute, so there is nothing to review.
+ClearPlan ==
+    /\ planPhase' = NoPlan
+    /\ planEffects' = NoEffects
+    /\ summaryEffects' = NoEffects
+    /\ planGen' = policyGen
+    /\ approved' = FALSE
+    /\ UNCHANGED <<dbEffects, policyGen, editsLeft, lostApproval>>
+
 \* Keep the plan and its decision; only the provenance advances.
 RetainPlan ==
     /\ summaryEffects' = dbEffects
@@ -155,7 +182,17 @@ ReconcilePending ==
     /\ planPhase = Pending
     /\ \/ /\ RevalidationMode = "semantic"
           \* Compare effects. Identical effects retain the plan and its
-          \* decision; changed effects supersede it.
+          \* decision; changed effects supersede it; vanished effects clear it.
+          /\ \/ /\ dbEffects = NoEffects
+                /\ ClearPlan
+             \/ /\ dbEffects /= NoEffects
+                /\ \/ /\ planEffects = dbEffects
+                      /\ RetainPlan
+                   \/ /\ planEffects /= dbEffects
+                      /\ SupersedeAndReplace
+       \/ /\ RevalidationMode = "replace"
+          \* Compare effects, but always leave a replacement behind, however
+          \* little it holds. The defect property 3 exists to catch.
           /\ \/ /\ planEffects = dbEffects
                 /\ RetainPlan
              \/ /\ planEffects /= dbEffects

--- a/correctness/races/PlanRevalidation.tla
+++ b/correctness/races/PlanRevalidation.tla
@@ -1,0 +1,186 @@
+---- MODULE PlanRevalidation ----
+EXTENDS FiniteSets, Naturals
+
+(*
+  Pending-plan revalidation for pgroles PostgresPolicyPlan.
+
+  While a plan awaits a manual decision, the policy keeps reconciling. Two
+  things must stay true across those reconciles, and they pull in opposite
+  directions:
+
+    1. What the policy *reports* and what the pending plan *holds* must
+       describe the same effects. Otherwise a reviewer reads a fresh change
+       summary, approves the plan beside it, and approves something else.
+
+    2. An approval must survive a policy edit that turns out to be
+       effect-neutral. Review is expensive; a comment change, a reordering, or
+       any edit the diff engine collapses to nothing must not cost a round.
+
+  `RevalidationMode` selects the strategy:
+
+    - "semantic"     (PlanRevalidation.cfg) — revalidate by comparing effects.
+                     Both properties hold.
+    - "frozen"       (PlanRevalidation_frozen.cfg) — today's behaviour: the
+                     Pending arm returns early without revalidating, refreshing
+                     the summary while the plan stands. Violates property 1.
+    - "generational" (PlanRevalidation_generational.cfg) — the plausible wrong
+                     fix: supersede whenever the policy generation moves.
+                     Property 1 holds, but property 2 fails — every
+                     effect-neutral edit throws away a decision. This is why
+                     `policyGeneration` is a revalidation *trigger* and the
+                     change digest is the *identity*.
+
+  What is NOT modeled: approval mechanics and execution (PlanApproval.tla),
+  crashes and locking (PlanLifecycle.tla).
+*)
+
+CONSTANTS
+    RevalidationMode,  \* "semantic" | "frozen" | "generational"
+    MaxEdits           \* Bound on policy edits, so the state space is finite
+
+NoPlan == "none"
+Pending == "Pending"
+
+\* Distinct semantic effect sets, standing in for change digests.
+Effects == {"e1", "e2"}
+NoEffects == "none"
+
+VARIABLES
+    planPhase,       \* Whether a plan is currently pending review
+    planEffects,     \* Effects the pending plan holds
+    planGen,         \* Policy generation the plan was last confirmed against
+    summaryEffects,  \* Effects the policy's status reports to the reader
+    approved,        \* A reviewer has decided on the current plan
+    dbEffects,       \* Effects the policy would produce right now
+    policyGen,       \* Current policy generation
+    editsLeft,       \* Remaining policy edits
+    lostApproval     \* Witness: an approval was discarded even though the
+                     \* effects under review had not changed
+
+vars == <<planPhase, planEffects, planGen, summaryEffects, approved,
+          dbEffects, policyGen, editsLeft, lostApproval>>
+
+TypeOK ==
+    /\ planPhase \in {NoPlan, Pending}
+    /\ planEffects \in Effects \cup {NoEffects}
+    /\ planGen \in 0..MaxEdits
+    /\ summaryEffects \in Effects \cup {NoEffects}
+    /\ approved \in BOOLEAN
+    /\ dbEffects \in Effects
+    /\ policyGen \in 0..MaxEdits
+    /\ editsLeft \in 0..MaxEdits
+    /\ lostApproval \in BOOLEAN
+
+\* --- Properties ---
+
+\* Property 1. A reviewer reading the policy's summary and opening the plan it
+\* points at must see the same change. The frozen strategy breaks this.
+SummaryMatchesPlan ==
+    (planPhase = Pending /\ summaryEffects /= NoEffects) =>
+        summaryEffects = planEffects
+
+\* Property 2. An effect-neutral policy edit must not discard a decision.
+\* The generational strategy breaks this.
+ApprovalSurvivesEffectNeutralEdits == ~lostApproval
+
+Init ==
+    /\ planPhase = NoPlan
+    /\ planEffects = NoEffects
+    /\ planGen = 0
+    /\ summaryEffects = NoEffects
+    /\ approved = FALSE
+    /\ dbEffects = "e1"
+    /\ policyGen = 0
+    /\ editsLeft = MaxEdits
+    /\ lostApproval = FALSE
+
+\* --- Actions ---
+
+OperatorCreatesPlan ==
+    /\ planPhase = NoPlan
+    /\ planPhase' = Pending
+    /\ planEffects' = dbEffects
+    /\ summaryEffects' = dbEffects
+    /\ planGen' = policyGen
+    /\ approved' = FALSE
+    /\ UNCHANGED <<dbEffects, policyGen, editsLeft, lostApproval>>
+
+\* A policy edit the diff engine collapses to nothing: the generation moves,
+\* the effects do not. Comment changes, reordering, redundant declarations.
+PolicyEditEffectNeutral ==
+    /\ editsLeft > 0
+    /\ policyGen' = policyGen + 1
+    /\ editsLeft' = editsLeft - 1
+    /\ UNCHANGED <<planPhase, planEffects, planGen, summaryEffects, approved,
+                    dbEffects, lostApproval>>
+
+\* A policy edit that genuinely changes what would be executed.
+PolicyEditEffective ==
+    /\ editsLeft > 0
+    /\ \E e \in Effects:
+        /\ e /= dbEffects
+        /\ dbEffects' = e
+    /\ policyGen' = policyGen + 1
+    /\ editsLeft' = editsLeft - 1
+    /\ UNCHANGED <<planPhase, planEffects, planGen, summaryEffects, approved,
+                    lostApproval>>
+
+UserApproves ==
+    /\ planPhase = Pending
+    /\ ~approved
+    /\ approved' = TRUE
+    /\ UNCHANGED <<planPhase, planEffects, planGen, summaryEffects, dbEffects,
+                    policyGen, editsLeft, lostApproval>>
+
+\* Replace the pending plan with one describing the current effects.
+SupersedeAndReplace ==
+    /\ planEffects' = dbEffects
+    /\ summaryEffects' = dbEffects
+    /\ planGen' = policyGen
+    /\ approved' = FALSE
+    \* Record the cost if a decision was discarded while the effects under
+    \* review were in fact unchanged.
+    /\ lostApproval' = (lostApproval \/ (approved /\ planEffects = dbEffects))
+    /\ UNCHANGED <<planPhase, dbEffects, policyGen, editsLeft>>
+
+\* Keep the plan and its decision; only the provenance advances.
+RetainPlan ==
+    /\ summaryEffects' = dbEffects
+    /\ planGen' = policyGen
+    /\ UNCHANGED <<planPhase, planEffects, approved, dbEffects, policyGen,
+                    editsLeft, lostApproval>>
+
+\* One reconcile while a plan is pending.
+ReconcilePending ==
+    /\ planPhase = Pending
+    /\ \/ /\ RevalidationMode = "semantic"
+          \* Compare effects. Identical effects retain the plan and its
+          \* decision; changed effects supersede it.
+          /\ \/ /\ planEffects = dbEffects
+                /\ RetainPlan
+             \/ /\ planEffects /= dbEffects
+                /\ SupersedeAndReplace
+       \/ /\ RevalidationMode = "frozen"
+          \* Today: refresh the reported summary and return, leaving the plan
+          \* untouched however far the effects have moved.
+          /\ summaryEffects' = dbEffects
+          /\ UNCHANGED <<planPhase, planEffects, planGen, approved, dbEffects,
+                          policyGen, editsLeft, lostApproval>>
+       \/ /\ RevalidationMode = "generational"
+          \* Supersede whenever the generation moved, without asking whether
+          \* the effects did.
+          /\ \/ /\ planGen = policyGen
+                /\ RetainPlan
+             \/ /\ planGen /= policyGen
+                /\ SupersedeAndReplace
+
+Next ==
+    \/ OperatorCreatesPlan
+    \/ PolicyEditEffectNeutral
+    \/ PolicyEditEffective
+    \/ UserApproves
+    \/ ReconcilePending
+
+Spec == Init /\ [][Next]_vars
+
+====

--- a/correctness/races/PlanRevalidation_frozen.cfg
+++ b/correctness/races/PlanRevalidation_frozen.cfg
@@ -1,0 +1,14 @@
+\* RevalidationMode = "frozen" — see PlanRevalidation.tla for what each proves.
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    RevalidationMode = "frozen"
+    MaxEdits = 2
+
+INVARIANT
+    TypeOK
+    SummaryMatchesPlan
+    ApprovalSurvivesEffectNeutralEdits

--- a/correctness/races/PlanRevalidation_generational.cfg
+++ b/correctness/races/PlanRevalidation_generational.cfg
@@ -1,0 +1,14 @@
+\* RevalidationMode = "generational" — see PlanRevalidation.tla for what each proves.
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    RevalidationMode = "generational"
+    MaxEdits = 2
+
+INVARIANT
+    TypeOK
+    SummaryMatchesPlan
+    ApprovalSurvivesEffectNeutralEdits

--- a/correctness/races/PlanRevalidation_replace.cfg
+++ b/correctness/races/PlanRevalidation_replace.cfg
@@ -1,11 +1,11 @@
-\* RevalidationMode = "semantic" — see PlanRevalidation.tla for what each proves.
+\* RevalidationMode = "replace" — see PlanRevalidation.tla for what each proves.
 
 SPECIFICATION Spec
 
 CHECK_DEADLOCK FALSE
 
 CONSTANTS
-    RevalidationMode = "semantic"
+    RevalidationMode = "replace"
     MaxEdits = 2
 
 INVARIANT

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1072,6 +1072,19 @@ pub struct PostgresPolicyPlanStatus {
     /// from different encodings are never comparable.
     #[serde(default)]
     pub change_digest_encoding: Option<String>,
+    /// The policy generation this plan was most recently confirmed current
+    /// against.
+    ///
+    /// A pending plan is revalidated on every reconcile. When the policy
+    /// changes but the resulting effects do not, the plan — and any decision
+    /// recorded on it — is retained and this advances to the new generation.
+    /// It is provenance, never approval identity: `change_digest` is what a
+    /// decision binds.
+    #[serde(default)]
+    pub revalidated_generation: Option<i64>,
+    /// When the plan was most recently confirmed current.
+    #[serde(default)]
+    pub revalidated_at: Option<String>,
     /// Timestamp when the plan entered Applying phase (for stuck detection).
     #[serde(default)]
     pub applying_since: Option<String>,

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1670,6 +1670,52 @@ pub(crate) fn decide_pending_plan(
     }
 }
 
+/// What to do with a plan that a reviewer has approved but that has not yet
+/// executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApprovedPlanDecision {
+    /// The approved effects are still the effects this policy would produce.
+    /// Execute what was reviewed.
+    Execute,
+    /// The effects moved between the decision and this reconcile. The approval
+    /// described something else, so it cannot authorise this — supersede and
+    /// open a new plan for review.
+    Replace,
+    /// The effects moved to nothing. Supersede and leave no plan behind, for
+    /// the same reason as `PendingPlanDecision::Clear`: a zero-change
+    /// replacement would demand a second approval that buys nothing while the
+    /// policy reports no drift beside it.
+    Clear,
+}
+
+/// Decide the fate of an approved plan against the effects the policy would
+/// produce right now.
+///
+/// This is the single gate between a recorded decision and executing DDL, so it
+/// fails closed: a plan whose status is missing, or written under an older
+/// digest encoding, cannot be shown to still hold the approved effects and is
+/// never executed.
+///
+/// Unlike [`decide_pending_plan`], a matching digest executes even when the
+/// change set is empty. An approved no-op plan is resolved by running it — that
+/// marks it Applied and releases the policy — whereas an unapproved no-op plan
+/// would sit waiting for a decision no one should have to make.
+pub(crate) fn decide_approved_plan(
+    plan_status: Option<&crate::crd::PostgresPolicyPlanStatus>,
+    fresh_digest: &str,
+    has_changes: bool,
+) -> ApprovedPlanDecision {
+    if plan_status.is_some_and(|status| plan_matches_digest(status, fresh_digest)) {
+        return ApprovedPlanDecision::Execute;
+    }
+
+    if has_changes {
+        ApprovedPlanDecision::Replace
+    } else {
+        ApprovedPlanDecision::Clear
+    }
+}
+
 /// Record that a pending plan was re-confirmed against the current policy.
 ///
 /// Called when the freshly computed effects still match what the plan holds, so
@@ -2528,6 +2574,12 @@ mod tests {
         };
         assert!(!needs_revalidation_record(&confirmed_at_3, Some(3)));
         assert!(needs_revalidation_record(&confirmed_at_3, Some(4)));
+        // A plan recorded against a *newer* generation than the one being
+        // reconciled — a stale watch-cache read — must also re-record, so the
+        // provenance always names the generation actually confirmed. Without
+        // this case the comparison could be `<` rather than `!=` and no test
+        // would notice.
+        assert!(needs_revalidation_record(&confirmed_at_3, Some(2)));
 
         // A plan from before this field existed gets its provenance filled in.
         let legacy = PostgresPolicyPlanStatus::default();
@@ -2690,16 +2742,125 @@ mod tests {
         );
     }
 
+    /// The gate between a recorded decision and executing DDL. Every case that
+    /// is not a proven match must refuse to execute — this is the one check
+    /// standing between an approval and running different SQL than was read.
+    #[test]
+    fn an_approval_executes_only_the_effects_it_was_given_for() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let approved_changes = [grant_change("reporting")];
+        let approved_digest = digest_for(&approved_changes, &versions);
+        let approved = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Approved,
+            change_digest: Some(approved_digest.clone()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            decide_approved_plan(Some(&approved), &approved_digest, true),
+            ApprovedPlanDecision::Execute,
+        );
+
+        // Effects moved after the decision: the approval described something
+        // else, so it must not authorise this.
+        assert_eq!(
+            decide_approved_plan(
+                Some(&approved),
+                &digest_for(&[grant_change("analytics")], &versions),
+                true
+            ),
+            ApprovedPlanDecision::Replace,
+        );
+
+        // Fail closed on anything that cannot be proven to match: no status
+        // yet, no digest at all, or a digest under an older encoding.
+        for unprovable in [
+            None,
+            Some(&PostgresPolicyPlanStatus::default()),
+            Some(&PostgresPolicyPlanStatus {
+                change_digest: Some(approved_digest.clone()),
+                change_digest_encoding: Some("pgroles.io/approval-effect/v0".to_string()),
+                ..Default::default()
+            }),
+        ] {
+            assert_ne!(
+                decide_approved_plan(unprovable, &approved_digest, true),
+                ApprovedPlanDecision::Execute,
+            );
+        }
+    }
+
+    /// The same no-op trap as the pending arm: if the approved effects are
+    /// applied by hand before the plan executes, superseding it must not leave
+    /// a zero-change replacement demanding a second approval.
+    #[test]
+    fn an_approved_plan_whose_effects_vanish_is_cleared_not_replaced() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let approved = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Approved,
+            change_digest: Some(digest_for(&[grant_change("reporting")], &versions)),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        let empty_digest = digest_for(&[], &versions);
+
+        assert_eq!(
+            decide_approved_plan(Some(&approved), &empty_digest, false),
+            ApprovedPlanDecision::Clear,
+        );
+
+        // An approved plan that genuinely holds nothing is resolved by running
+        // it — that marks it Applied and releases the policy, rather than
+        // superseding it into another decision no one should have to make.
+        let approved_empty = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Approved,
+            change_digest: Some(empty_digest.clone()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            decide_approved_plan(Some(&approved_empty), &empty_digest, false),
+            ApprovedPlanDecision::Execute,
+        );
+    }
+
     /// Planning must never persist password material, in any field.
+    ///
+    /// Asserted against the *pre-hash* canonical bytes, not the digest string.
+    /// Checking that a SHA-256 hex string does not contain the verifier is true
+    /// of any hash of any input, so it would pass even while the verifier was
+    /// being hashed in — the same trap the core suite documents at
+    /// `approval::the_digest_never_contains_password_material`.
     #[test]
     fn the_digest_carries_no_password_material() {
         let verifier = "SCRAM-SHA-256$4096:c2FsdA==$c3RvcmVk:c2VydmVy";
-        let digest = digest_for(
-            &[set_password("app", verifier)],
-            &password_versions("app", "role-passwords:app:7"),
-        );
+        let changes = [set_password("app", verifier)];
+        let versions = password_versions("app", "role-passwords:app:7");
 
-        assert!(digest.starts_with("sha256:"));
-        assert!(!digest.contains(verifier));
+        let bytes = pgroles_core::approval::canonical_change_set_bytes(
+            &changes,
+            &pgroles_core::approval::EffectDigestInputs {
+                reconciliation_mode: CrdReconciliationMode::default().into(),
+                target: "default/db-credentials:DATABASE_URL",
+                password_source_versions: &versions,
+            },
+        )
+        .expect("canonical bytes");
+        let encoded = String::from_utf8(bytes).expect("canonical bytes are UTF-8");
+
+        assert!(
+            !encoded.contains(verifier),
+            "verifier reached the digest input: {encoded}"
+        );
+        assert!(
+            !encoded.contains("c3RvcmVk"),
+            "stored key reached the digest input: {encoded}"
+        );
+        // The password *source version* is what the digest binds instead, so a
+        // rotation is a new approval while a re-salted verifier is not.
+        assert!(encoded.contains("role-passwords:app:7"));
+
+        assert!(digest_for(&changes, &versions).starts_with("sha256:"));
     }
 }

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1632,6 +1632,44 @@ pub(crate) fn needs_revalidation_record(
     status.revalidated_generation != generation
 }
 
+/// What to do with a plan that is still awaiting a manual decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PendingPlanDecision {
+    /// The effects are unchanged. The plan, and any decision on it, stand.
+    Retain,
+    /// The effects moved. Supersede the plan and open a new one for review.
+    Replace,
+    /// The effects are gone. Supersede the plan and leave none in its place —
+    /// a replacement would hold no changes yet still demand an approval, and
+    /// the policy would report `Drifted=False` while blocked on it.
+    Clear,
+}
+
+/// Decide the fate of a pending plan against the effects the policy would
+/// produce right now.
+///
+/// `plan_status` is `None` for a plan whose status has not been written yet;
+/// like a plan under an older digest encoding it cannot be shown to still hold
+/// the current effects, so it is superseded rather than trusted.
+pub(crate) fn decide_pending_plan(
+    plan_status: Option<&crate::crd::PostgresPolicyPlanStatus>,
+    fresh_digest: &str,
+    has_changes: bool,
+) -> PendingPlanDecision {
+    // Nothing to execute means nothing to approve, whatever the plan holds.
+    // A plan that still matches an empty change set is itself a no-op, so it
+    // is cleared too rather than left blocking on a decision.
+    if !has_changes {
+        return PendingPlanDecision::Clear;
+    }
+
+    if plan_status.is_some_and(|status| plan_matches_digest(status, fresh_digest)) {
+        PendingPlanDecision::Retain
+    } else {
+        PendingPlanDecision::Replace
+    }
+}
+
 /// Record that a pending plan was re-confirmed against the current policy.
 ///
 /// Called when the freshly computed effects still match what the plan holds, so
@@ -2579,6 +2617,77 @@ mod tests {
             ..Default::default()
         };
         assert!(!plan_matches_digest(&different_effects, &digest));
+    }
+
+    /// A pending plan whose effects disappear before anyone decides on it must
+    /// leave no plan behind. Replacing it with an empty one would park the
+    /// policy on an approval for nothing while it reports `Drifted=False`.
+    #[test]
+    fn a_pending_plan_whose_effects_vanish_is_cleared_not_replaced() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let planned = digest_for(&[grant_change("reporting")], &versions);
+        let pending = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Pending,
+            change_digest: Some(planned),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        let empty_digest = digest_for(&[], &versions);
+
+        assert_eq!(
+            decide_pending_plan(Some(&pending), &empty_digest, false),
+            PendingPlanDecision::Clear,
+        );
+
+        // Even a plan that legitimately matches an empty change set holds
+        // nothing to approve, so it is cleared rather than retained.
+        let empty_plan = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Pending,
+            change_digest: Some(empty_digest.clone()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            decide_pending_plan(Some(&empty_plan), &empty_digest, false),
+            PendingPlanDecision::Clear,
+        );
+    }
+
+    #[test]
+    fn a_pending_plan_is_replaced_only_when_real_effects_moved() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let original = [grant_change("reporting")];
+        let edited = [grant_change("analytics")];
+        let pending = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Pending,
+            change_digest: Some(digest_for(&original, &versions)),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            decide_pending_plan(Some(&pending), &digest_for(&original, &versions), true),
+            PendingPlanDecision::Retain,
+        );
+        assert_eq!(
+            decide_pending_plan(Some(&pending), &digest_for(&edited, &versions), true),
+            PendingPlanDecision::Replace,
+        );
+
+        // A plan with no status yet, or one written under an older encoding,
+        // cannot be shown to hold the current effects — fail closed.
+        assert_eq!(
+            decide_pending_plan(None, &digest_for(&original, &versions), true),
+            PendingPlanDecision::Replace,
+        );
+        assert_eq!(
+            decide_pending_plan(
+                Some(&PostgresPolicyPlanStatus::default()),
+                &digest_for(&original, &versions),
+                true
+            ),
+            PendingPlanDecision::Replace,
+        );
     }
 
     /// Planning must never persist password material, in any field.

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -433,6 +433,8 @@ pub async fn create_or_update_plan(
         sql_hash: Some(sql_hash),
         change_digest: Some(change_digest),
         change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+        revalidated_generation: Some(generation),
+        revalidated_at: Some(crate::crd::now_rfc3339()),
         applying_since: None,
         failed_at: None,
         sql_statements: Some(sql_statement_count),
@@ -1618,6 +1620,49 @@ pub async fn mark_plan_superseded(
     Ok(())
 }
 
+/// Whether a pending plan needs its revalidation provenance refreshed.
+///
+/// The plan's effects have already been confirmed current by the caller; this
+/// only decides whether the *record* of that confirmation is stale. Patching on
+/// every reconcile would churn the object and its events for no information.
+pub(crate) fn needs_revalidation_record(
+    status: &crate::crd::PostgresPolicyPlanStatus,
+    generation: Option<i64>,
+) -> bool {
+    status.revalidated_generation != generation
+}
+
+/// Record that a pending plan was re-confirmed against the current policy.
+///
+/// Called when the freshly computed effects still match what the plan holds, so
+/// the plan and any decision on it survive a policy change that turned out to
+/// be effect-neutral.
+pub async fn record_plan_revalidation(
+    client: &Client,
+    plan: &PostgresPolicyPlan,
+    generation: Option<i64>,
+) -> Result<(), ReconcileError> {
+    let namespace = plan.namespace().ok_or(ReconcileError::NoNamespace)?;
+    let plan_name = plan.name_any();
+    let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
+
+    let patch = serde_json::json!({
+        "status": {
+            "revalidatedGeneration": generation,
+            "revalidatedAt": crate::crd::now_rfc3339(),
+        }
+    });
+    plans_api
+        .patch_status(
+            &plan_name,
+            &PatchParams::apply("pgroles-operator"),
+            &Patch::Merge(&patch),
+        )
+        .await?;
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -2361,6 +2406,18 @@ mod tests {
         }
     }
 
+    fn grant_change(role: &str) -> pgroles_core::diff::Change {
+        pgroles_core::diff::Change::Grant {
+            role: role.to_string(),
+            privileges: [pgroles_core::manifest::Privilege::Select]
+                .into_iter()
+                .collect(),
+            object_type: pgroles_core::manifest::ObjectType::Table,
+            schema: Some("inventory".to_string()),
+            name: Some("orders".to_string()),
+        }
+    }
+
     fn digest_for(
         changes: &[pgroles_core::diff::Change],
         versions: &BTreeMap<String, String>,
@@ -2417,6 +2474,73 @@ mod tests {
             digest_for(&change, &password_versions("app", "role-passwords:app:7")),
             digest_for(&change, &password_versions("app", "role-passwords:app:8")),
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending-plan revalidation (Phase 0.2)
+    // -----------------------------------------------------------------------
+
+    /// Provenance is refreshed only when the generation it records has moved,
+    /// so an unchanged policy does not rewrite the plan on every reconcile.
+    #[test]
+    fn revalidation_is_recorded_once_per_generation() {
+        let confirmed_at_3 = PostgresPolicyPlanStatus {
+            revalidated_generation: Some(3),
+            ..Default::default()
+        };
+        assert!(!needs_revalidation_record(&confirmed_at_3, Some(3)));
+        assert!(needs_revalidation_record(&confirmed_at_3, Some(4)));
+
+        // A plan from before this field existed gets its provenance filled in.
+        let legacy = PostgresPolicyPlanStatus::default();
+        assert!(needs_revalidation_record(&legacy, Some(1)));
+
+        // A policy with no generation at all is consistent with itself.
+        assert!(!needs_revalidation_record(&legacy, None));
+    }
+
+    /// The revalidation decision is exactly the digest comparison: a policy
+    /// edit that leaves effects untouched must not cost a review round, and one
+    /// that changes them must not leave a reviewable plan describing the old
+    /// effects.
+    #[test]
+    fn a_pending_plan_is_retained_only_while_its_effects_hold() {
+        let versions = password_versions("app", "role-passwords:app:7");
+        let original = [grant_change("reporting")];
+        let edited = [grant_change("analytics")];
+
+        let planned = digest_for(&original, &versions);
+        let pending = PostgresPolicyPlanStatus {
+            phase: PlanPhase::Pending,
+            change_digest: Some(planned.clone()),
+            change_digest_encoding: Some(APPROVAL_EFFECT_ENCODING_V1.to_string()),
+            revalidated_generation: Some(1),
+            ..Default::default()
+        };
+
+        // Effect-neutral policy edit: same effects, later generation.
+        assert!(plan_matches_digest(
+            &pending,
+            &digest_for(&original, &versions)
+        ));
+        assert!(needs_revalidation_record(&pending, Some(2)));
+
+        // Effects changed: the plan can no longer be the one under review.
+        assert!(!plan_matches_digest(
+            &pending,
+            &digest_for(&edited, &versions)
+        ));
+    }
+
+    #[test]
+    fn a_newly_created_plan_records_its_own_generation_as_confirmed() {
+        // Guards the invariant that a plan is never born already looking stale,
+        // which would make the first reconcile after creation patch it.
+        let fresh = PostgresPolicyPlanStatus {
+            revalidated_generation: Some(7),
+            ..Default::default()
+        };
+        assert!(!needs_revalidation_record(&fresh, Some(7)));
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1344,35 +1344,13 @@ async fn apply_under_lock(
                                     "approved plan superseded with no remaining changes"
                                 );
 
-                                update_status(ctx, resource, |status| {
-                                    status.set_condition(ready_condition(
-                                        true,
-                                        "Reconciled",
-                                        "No changes needed",
-                                    ));
-                                    status.set_condition(drifted_condition(
-                                        false,
-                                        "InSync",
-                                        "No pending changes",
-                                    ));
-                                    status.conditions.retain(|c| {
-                                        c.condition_type != "Reconciling"
-                                            && c.condition_type != "Degraded"
-                                            && c.condition_type != "Conflict"
-                                            && c.condition_type != "Paused"
-                                    });
-                                    status.observed_generation = generation;
-                                    status.last_attempted_generation = generation;
-                                    status.last_successful_reconcile_time =
-                                        Some(crate::crd::now_rfc3339());
-                                    status.change_summary = Some(summary.clone());
-                                    status.last_reconcile_mode = Some(PolicyMode::Apply);
-                                    status.current_plan_ref = None;
-                                    status.last_error = None;
-                                    status.applied_password_source_versions =
-                                        applied_password_source_versions.clone();
-                                    status.transient_failure_count = 0;
-                                })
+                                mark_reconciled_no_changes(
+                                    ctx,
+                                    resource,
+                                    generation,
+                                    summary.clone(),
+                                    applied_password_source_versions.clone(),
+                                )
                                 .await?;
 
                                 return Ok((
@@ -1608,7 +1586,8 @@ async fn apply_under_lock(
                                 name,
                                 namespace,
                                 plan = %current_plan.name_any(),
-                                "pending plan superseded: effects changed while awaiting approval"
+                                ?decision,
+                                "pending plan superseded while awaiting approval"
                             );
 
                             crate::plan::mark_plan_superseded(&ctx.kube_client, &current_plan)
@@ -1619,40 +1598,13 @@ async fn apply_under_lock(
                             // demand a decision, so leave the policy with no
                             // pending plan at all.
                             if decision == crate::plan::PendingPlanDecision::Clear {
-                                info!(
-                                    name,
-                                    namespace, "pending plan superseded with no remaining changes"
-                                );
-
-                                update_status(ctx, resource, |status| {
-                                    status.set_condition(ready_condition(
-                                        true,
-                                        "Reconciled",
-                                        "No changes needed",
-                                    ));
-                                    status.set_condition(drifted_condition(
-                                        false,
-                                        "InSync",
-                                        "No pending changes",
-                                    ));
-                                    status.conditions.retain(|c| {
-                                        c.condition_type != "Reconciling"
-                                            && c.condition_type != "Degraded"
-                                            && c.condition_type != "Conflict"
-                                            && c.condition_type != "Paused"
-                                    });
-                                    status.observed_generation = generation;
-                                    status.last_attempted_generation = generation;
-                                    status.last_successful_reconcile_time =
-                                        Some(crate::crd::now_rfc3339());
-                                    status.change_summary = Some(summary.clone());
-                                    status.last_reconcile_mode = Some(PolicyMode::Apply);
-                                    status.current_plan_ref = None;
-                                    status.last_error = None;
-                                    status.applied_password_source_versions =
-                                        applied_password_source_versions.clone();
-                                    status.transient_failure_count = 0;
-                                })
+                                mark_reconciled_no_changes(
+                                    ctx,
+                                    resource,
+                                    generation,
+                                    summary.clone(),
+                                    applied_password_source_versions.clone(),
+                                )
                                 .await?;
 
                                 return Ok((
@@ -1681,13 +1633,11 @@ async fn apply_under_lock(
                                     summary.total,
                                 );
                                 status.set_condition(ready_condition(true, "Planned", &msg));
+                                // Replace implies a non-empty change set; the
+                                // empty case returned above as Clear.
                                 status.set_condition(drifted_condition(
-                                    !changes.is_empty(),
-                                    if changes.is_empty() {
-                                        "InSync"
-                                    } else {
-                                        "DriftDetected"
-                                    },
+                                    true,
+                                    "DriftDetected",
                                     &msg,
                                 ));
                                 status.conditions.retain(|c| {
@@ -1778,24 +1728,18 @@ async fn apply_under_lock(
             if changes.is_empty() {
                 info!(name, namespace, "no changes needed (manual approval mode)");
 
-                update_status(ctx, resource, |status| {
-                    status.set_condition(ready_condition(true, "Reconciled", "No changes needed"));
-                    status.set_condition(drifted_condition(false, "InSync", "No pending changes"));
-                    status.conditions.retain(|c| {
-                        c.condition_type != "Reconciling"
-                            && c.condition_type != "Degraded"
-                            && c.condition_type != "Conflict"
-                            && c.condition_type != "Paused"
-                    });
-                    status.observed_generation = generation;
-                    status.last_attempted_generation = generation;
-                    status.last_successful_reconcile_time = Some(crate::crd::now_rfc3339());
-                    status.change_summary = Some(summary);
-                    status.last_reconcile_mode = Some(PolicyMode::Apply);
-                    status.last_error = None;
-                    status.applied_password_source_versions = applied_password_source_versions;
-                    status.transient_failure_count = 0;
-                })
+                // Reached only when no actionable plan exists, so the helper
+                // clearing `current_plan_ref` is what this path always meant:
+                // previously it left a reference to whatever plan had been
+                // superseded, which outlived the plan itself once retention
+                // pruned it.
+                mark_reconciled_no_changes(
+                    ctx,
+                    resource,
+                    generation,
+                    summary,
+                    applied_password_source_versions,
+                )
                 .await?;
 
                 return Ok((
@@ -2260,6 +2204,43 @@ async fn emit_plan_event(
 }
 
 /// Patch the status sub-resource of a PostgresPolicy.
+/// Record that the policy is in sync with nothing left to do.
+///
+/// Three paths reach this state under manual approval — no plan and no changes,
+/// a pending plan whose effects vanished, and an approved plan whose effects
+/// vanished — and they must report it identically. Written once here so a field
+/// added later cannot be added to two of the three.
+async fn mark_reconciled_no_changes(
+    ctx: &OperatorContext,
+    resource: &PostgresPolicy,
+    generation: Option<i64>,
+    summary: crate::crd::ChangeSummary,
+    applied_password_source_versions: std::collections::BTreeMap<String, String>,
+) -> Result<(), ReconcileError> {
+    update_status(ctx, resource, |status| {
+        status.set_condition(ready_condition(true, "Reconciled", "No changes needed"));
+        status.set_condition(drifted_condition(false, "InSync", "No pending changes"));
+        status.conditions.retain(|c| {
+            c.condition_type != "Reconciling"
+                && c.condition_type != "Degraded"
+                && c.condition_type != "Conflict"
+                && c.condition_type != "Paused"
+        });
+        status.observed_generation = generation;
+        status.last_attempted_generation = generation;
+        status.last_successful_reconcile_time = Some(crate::crd::now_rfc3339());
+        status.change_summary = Some(summary);
+        status.last_reconcile_mode = Some(PolicyMode::Apply);
+        // Whatever plan was pointed at is gone; leaving the reference behind
+        // strands it on a superseded or pruned object.
+        status.current_plan_ref = None;
+        status.last_error = None;
+        status.applied_password_source_versions = applied_password_source_versions;
+        status.transient_failure_count = 0;
+    })
+    .await
+}
+
 async fn update_status<F>(
     ctx: &OperatorContext,
     resource: &PostgresPolicy,

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1529,7 +1529,103 @@ async fn apply_under_lock(
                         return Ok((Action::requeue(requeue_interval), ReconcileOutcome::Planned));
                     }
                     crate::plan::PlanApprovalState::Pending => {
-                        // Plan exists and is pending — nothing to do, requeue.
+                        // Revalidate the pending plan against the effects the
+                        // policy would produce right now. Without this the plan
+                        // is frozen while awaiting a decision, so the policy can
+                        // report a fresh change summary beside a plan holding
+                        // different content — and a reviewer approves the stale
+                        // one.
+                        let fresh_digest = crate::plan::compute_change_digest(
+                            &changes,
+                            resource.spec.reconciliation_mode,
+                            identity.as_str(),
+                            &applied_password_source_versions,
+                        )?;
+                        let plan_status = current_plan.status.as_ref();
+                        let still_current = plan_status.is_some_and(|status| {
+                            crate::plan::plan_matches_digest(status, &fresh_digest)
+                        });
+
+                        if !still_current {
+                            // The effects moved. Supersede rather than leave a
+                            // reviewable plan that no longer describes what
+                            // would happen.
+                            info!(
+                                name,
+                                namespace,
+                                plan = %current_plan.name_any(),
+                                "pending plan superseded: effects changed while awaiting approval"
+                            );
+
+                            crate::plan::mark_plan_superseded(&ctx.kube_client, &current_plan)
+                                .await?;
+
+                            let creation_result = crate::plan::create_or_update_plan(
+                                &ctx.kube_client,
+                                resource,
+                                &changes,
+                                &sql_ctx,
+                                &inspect_config,
+                                resource.spec.reconciliation_mode,
+                                identity.as_str(),
+                                &summary,
+                                &applied_password_source_versions,
+                            )
+                            .await?;
+                            let replacement = creation_result.plan_name().to_string();
+
+                            update_status(ctx, resource, |status| {
+                                let msg = format!(
+                                    "Plan {replacement} awaiting approval; {} change(s) pending",
+                                    summary.total,
+                                );
+                                status.set_condition(ready_condition(true, "Planned", &msg));
+                                status.set_condition(drifted_condition(
+                                    !changes.is_empty(),
+                                    if changes.is_empty() {
+                                        "InSync"
+                                    } else {
+                                        "DriftDetected"
+                                    },
+                                    &msg,
+                                ));
+                                status.conditions.retain(|c| {
+                                    c.condition_type != "Reconciling"
+                                        && c.condition_type != "Degraded"
+                                        && c.condition_type != "Conflict"
+                                        && c.condition_type != "Paused"
+                                });
+                                status.last_attempted_generation = generation;
+                                status.change_summary = Some(summary.clone());
+                                status.current_plan_ref = Some(crate::crd::PlanReference {
+                                    name: replacement.clone(),
+                                });
+                                status.last_error = None;
+                                status.transient_failure_count = 0;
+                            })
+                            .await?;
+
+                            return Ok((
+                                Action::requeue(requeue_interval),
+                                ReconcileOutcome::Planned,
+                            ));
+                        }
+
+                        // Effects unchanged — the plan, and any decision on it,
+                        // stand. Record the generation it was confirmed against
+                        // so an effect-neutral policy edit is visible as
+                        // provenance rather than looking like a stale plan.
+                        if plan_status
+                            .is_some_and(|s| crate::plan::needs_revalidation_record(s, generation))
+                        {
+                            crate::plan::record_plan_revalidation(
+                                &ctx.kube_client,
+                                &current_plan,
+                                generation,
+                            )
+                            .await?;
+                        }
+
                         info!(
                             name,
                             namespace,
@@ -1561,6 +1657,12 @@ async fn apply_under_lock(
                             });
                             status.last_attempted_generation = generation;
                             status.change_summary = Some(summary.clone());
+                            // The summary and the plan reference must always
+                            // describe the same effects; the plan was just
+                            // confirmed to still hold them.
+                            status.current_plan_ref = Some(crate::crd::PlanReference {
+                                name: current_plan.name_any(),
+                            });
                             status.last_error = None;
                             status.transient_failure_count = 0;
                         })

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1309,11 +1309,13 @@ async fn apply_under_lock(
                             identity.as_str(),
                             &applied_password_source_versions,
                         )?;
-                        let digest_matches = current_plan.status.as_ref().is_some_and(|status| {
-                            crate::plan::plan_matches_digest(status, &fresh_digest)
-                        });
+                        let decision = crate::plan::decide_approved_plan(
+                            current_plan.status.as_ref(),
+                            &fresh_digest,
+                            !changes.is_empty(),
+                        );
 
-                        if !digest_matches {
+                        if decision != crate::plan::ApprovedPlanDecision::Execute {
                             // The approved effects are no longer the effects
                             // this policy would produce.
                             let stored_digest = current_plan
@@ -1329,6 +1331,55 @@ async fn apply_under_lock(
 
                             crate::plan::mark_plan_superseded(&ctx.kube_client, &current_plan)
                                 .await?;
+
+                            // The effects did not just move, they vanished —
+                            // someone applied them by hand, or an edit removed
+                            // them. A replacement would hold nothing and still
+                            // demand a second approval.
+                            if decision == crate::plan::ApprovedPlanDecision::Clear {
+                                info!(
+                                    name,
+                                    namespace,
+                                    plan = %current_plan.name_any(),
+                                    "approved plan superseded with no remaining changes"
+                                );
+
+                                update_status(ctx, resource, |status| {
+                                    status.set_condition(ready_condition(
+                                        true,
+                                        "Reconciled",
+                                        "No changes needed",
+                                    ));
+                                    status.set_condition(drifted_condition(
+                                        false,
+                                        "InSync",
+                                        "No pending changes",
+                                    ));
+                                    status.conditions.retain(|c| {
+                                        c.condition_type != "Reconciling"
+                                            && c.condition_type != "Degraded"
+                                            && c.condition_type != "Conflict"
+                                            && c.condition_type != "Paused"
+                                    });
+                                    status.observed_generation = generation;
+                                    status.last_attempted_generation = generation;
+                                    status.last_successful_reconcile_time =
+                                        Some(crate::crd::now_rfc3339());
+                                    status.change_summary = Some(summary.clone());
+                                    status.last_reconcile_mode = Some(PolicyMode::Apply);
+                                    status.current_plan_ref = None;
+                                    status.last_error = None;
+                                    status.applied_password_source_versions =
+                                        applied_password_source_versions.clone();
+                                    status.transient_failure_count = 0;
+                                })
+                                .await?;
+
+                                return Ok((
+                                    Action::requeue(requeue_interval),
+                                    ReconcileOutcome::Reconciled,
+                                ));
+                            }
 
                             // Create a new plan with the fresh changes.
                             let new_creation_result = crate::plan::create_or_update_plan(
@@ -1403,7 +1454,8 @@ async fn apply_under_lock(
                             ));
                         }
 
-                        // Hash matches — safe to execute the approved plan.
+                        // The approved effects are still the effects this
+                        // policy would produce — execute what was reviewed.
                         info!(
                             name,
                             namespace,

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1542,11 +1542,13 @@ async fn apply_under_lock(
                             &applied_password_source_versions,
                         )?;
                         let plan_status = current_plan.status.as_ref();
-                        let still_current = plan_status.is_some_and(|status| {
-                            crate::plan::plan_matches_digest(status, &fresh_digest)
-                        });
+                        let decision = crate::plan::decide_pending_plan(
+                            plan_status,
+                            &fresh_digest,
+                            !changes.is_empty(),
+                        );
 
-                        if !still_current {
+                        if decision != crate::plan::PendingPlanDecision::Retain {
                             // The effects moved. Supersede rather than leave a
                             // reviewable plan that no longer describes what
                             // would happen.
@@ -1559,6 +1561,53 @@ async fn apply_under_lock(
 
                             crate::plan::mark_plan_superseded(&ctx.kube_client, &current_plan)
                                 .await?;
+
+                            // The effects did not just move, they vanished. A
+                            // replacement plan here would hold nothing and still
+                            // demand a decision, so leave the policy with no
+                            // pending plan at all.
+                            if decision == crate::plan::PendingPlanDecision::Clear {
+                                info!(
+                                    name,
+                                    namespace, "pending plan superseded with no remaining changes"
+                                );
+
+                                update_status(ctx, resource, |status| {
+                                    status.set_condition(ready_condition(
+                                        true,
+                                        "Reconciled",
+                                        "No changes needed",
+                                    ));
+                                    status.set_condition(drifted_condition(
+                                        false,
+                                        "InSync",
+                                        "No pending changes",
+                                    ));
+                                    status.conditions.retain(|c| {
+                                        c.condition_type != "Reconciling"
+                                            && c.condition_type != "Degraded"
+                                            && c.condition_type != "Conflict"
+                                            && c.condition_type != "Paused"
+                                    });
+                                    status.observed_generation = generation;
+                                    status.last_attempted_generation = generation;
+                                    status.last_successful_reconcile_time =
+                                        Some(crate::crd::now_rfc3339());
+                                    status.change_summary = Some(summary.clone());
+                                    status.last_reconcile_mode = Some(PolicyMode::Apply);
+                                    status.current_plan_ref = None;
+                                    status.last_error = None;
+                                    status.applied_password_source_versions =
+                                        applied_password_source_versions.clone();
+                                    status.transient_failure_count = 0;
+                                })
+                                .await?;
+
+                                return Ok((
+                                    Action::requeue(requeue_interval),
+                                    ReconcileOutcome::Reconciled,
+                                ));
+                            }
 
                             let creation_result = crate::plan::create_or_update_plan(
                                 &ctx.kube_client,

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -352,6 +352,17 @@
                     "nullable": true,
                     "type": "string"
                   },
+                  "revalidatedAt": {
+                    "description": "When the plan was most recently confirmed current.",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "revalidatedGeneration": {
+                    "description": "The policy generation this plan was most recently confirmed current\nagainst.\n\nA pending plan is revalidated on every reconcile. When the policy\nchanges but the resulting effects do not, the plan — and any decision\nrecorded on it — is retained and this advances to the new generation.\nIt is provenance, never approval identity: `change_digest` is what a\ndecision binds.",
+                    "format": "int64",
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "sqlHash": {
                     "description": "SHA-256 hash of the planned SQL. Retained as a diagnostic for the\npreview artifact; it is **not** the approval identity, because rendered\nSQL embeds a freshly salted SCRAM verifier for every password change.\nUse `change_digest` for approval and deduplication.",
                     "nullable": true,


### PR DESCRIPTION
Phase 0 item 2 of #173, building on the change digest from #177. Targets `main` directly.

## The problem

With `mode: apply` and `approval: manual`, the Pending arm returned early and did **no revalidation at all**. `status.change_summary` was refreshed from the freshly computed diff while `status.current_plan_ref` still pointed at the frozen plan — so status and plan could describe different content, and the plan was the stale one. A reviewer approving it approved something that was no longer what would happen.

The only escapes were rejecting the plan, or approving it and letting the approve-time comparison supersede it — consuming the approval without effect and forcing a second review round.

## What changed

A pending plan is revalidated on every reconcile by recomputing the canonical change digest. `plan::decide_pending_plan` is a pure function over the plan status and whether any changes remain, and it names three outcomes:

- **`Retain`** — effects unchanged. The plan *and any decision on it* stand, and the policy generation it was confirmed against is recorded as provenance.
- **`Replace`** — effects moved. The plan is superseded, a replacement is created, and `current_plan_ref` moves to it.
- **`Clear`** — effects vanished. The plan is superseded and **no replacement is opened**. Nothing to execute means nothing to approve; a zero-change replacement would block on an approval while the policy reported `Drifted=False` beside it. A plan whose digest matches an empty change set is cleared too — it holds nothing to approve however it got there.

The retained path also pins `current_plan_ref` to the plan the summary describes, so the two cannot diverge. Provenance is written only when the recorded generation actually moved — patching on every reconcile would churn the object and its Events for no information.

## Verification

**Unit** — retention only while effects hold; provenance recorded once per generation; a newly created plan records its own generation, so it is never born looking stale (which would make the first reconcile after creation patch it); vanished effects clear rather than replace; a missing or older-encoding digest fails closed to `Replace`.

**Model checking** (`correctness/races/PlanRevalidation.tla`) — the core properties here are *pairing* and *non-emptiness* invariants across reconciles, which unit tests cannot express. Three failing configurations bracket the design:

| Config | `RevalidationMode` | Result |
| --- | --- | --- |
| `PlanRevalidation.cfg` | `semantic` | passes (110 states) |
| `PlanRevalidation_frozen.cfg` | `frozen` | `SummaryMatchesPlan` violated |
| `PlanRevalidation_generational.cfg` | `generational` | `ApprovalSurvivesEffectNeutralEdits` violated |
| `PlanRevalidation_replace.cfg` | `replace` | `NoEmptyPendingPlan` violated (31 states) |

`frozen` reproduces the behaviour this PR replaces. `generational` is the plausible **wrong** fix — supersede whenever the policy generation moves: it restores the pairing but discards a decision on every effect-neutral edit. That is the formal argument for why `policyGeneration` is a revalidation *trigger* and the change digest is the *identity*, rather than a stylistic preference. `replace` is the narrower mistake — revalidate semantically but always leave a replacement behind — and is the defect CodeRabbit caught on the first commit, now reproduced as a model violation rather than only as a regression test.

## Local verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all`, `scripts/check-crd-drift.sh`, `scripts/check-helm-docs.sh`, and all four TLC configurations.

CRDs regenerated for the two new status fields, with all committed copies refreshed.

## Not in this PR

Phase 0 items 3–5 are tracked as #179 (write-once decisions), #180 (tiered target identity) and #181 (plan-neutral password Secrets). Documentation for the end state already describes this behaviour — [Plan and approval](https://hardbyte.github.io/pgroles/docs/operator-plan-approval) shipped in #176 — so no doc change is needed here beyond the correctness README.

Closes #178. Refs #173.

https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plans are now revalidated against the latest policy effects before execution.
  * Changed approved or pending plans are replaced with updated plans, while unchanged plans retain valid approvals.
  * No-op plans are automatically cleared instead of being executed.
  * Plan status now reports the last revalidation time and policy generation.

* **Bug Fixes**
  * Prevented stale or effect-mismatched approvals from being executed.

* **Documentation**
  * Added formal correctness documentation and model checks for plan revalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->