### PR TITLE
feat(operator): write-once plan decisions with a recorded decider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,15 @@ jobs:
           wait_for_condition_status plan-policy ApprovalIgnored True
           wait_for_event_reason plan-policy ApprovalIgnored
           assert_role_absent plan-preview-user
-          kubectl annotate pgplan "$plan_preview_plan" pgroles.io/approved- --overwrite
-          wait_for_condition_absent plan-policy ApprovalIgnored
+
+          # A decision is terminal, so there is no un-approving: removing the
+          # retired annotation is a no-op, and the warning must persist rather
+          # than clear. This previously deleted `pgroles.io/approved` and waited
+          # for ApprovalIgnored to disappear — the mutable-annotation model that
+          # write-once decisions replaced.
+          kubectl annotate pgplan "$plan_preview_plan" pgroles.io/approved- --overwrite || true
+          wait_for_condition_status plan-policy ApprovalIgnored True
+          assert_role_absent plan-preview-user
 
           upsert_secret rotating-postgres-credentials \
             DATABASE_URL='postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/postgres'

--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -180,7 +180,7 @@
                 "type": "object"
               },
               "status": {
-                "description": "Status of a `PostgresPolicyPlan` resource.",
+                "description": "Status of a `PostgresPolicyPlan` resource.\n\nThe decision rules below are the same grammar `EphemeralAccessRequest`\nuses: a decision is terminal, `Approved` and `Denied` cannot both be true,\nand the deciding identity is recorded in the same admitted write. What CEL\ncannot do is check *who* is writing — see [`DecisionActor`].",
                 "nullable": true,
                 "properties": {
                   "appliedAt": {
@@ -287,7 +287,7 @@
                   },
                   "conditions": {
                     "default": [],
-                    "description": "Standard conditions: Computed, Approved, Applied.",
+                    "description": "Standard conditions: Computed, Applied, and the terminal decision\nconditions `Approved` / `Denied`.",
                     "items": {
                       "description": "A condition on the `PostgresPolicy` resource.",
                       "properties": {
@@ -322,6 +322,36 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "decidedBy": {
+                    "description": "Kubernetes identity which approved or denied this plan.\n\nWritten in the same status update as the terminal decision, and\nwrite-once thereafter. The supplied Kyverno reference policy overwrites\nit from authenticated admission `userInfo`; without that admission layer\nit is an assertion by whoever wrote the status, not a verified identity.",
+                    "nullable": true,
+                    "properties": {
+                      "groups": {
+                        "default": [],
+                        "items": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "maxItems": 64,
+                        "type": "array"
+                      },
+                      "uid": {
+                        "maxLength": 128,
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "username": {
+                        "maxLength": 512,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "username"
+                    ],
+                    "type": "object"
                   },
                   "failedAt": {
                     "description": "Timestamp when the plan entered Failed phase (for dedup window).",
@@ -423,7 +453,25 @@
                     "type": "boolean"
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "Approved=True and Denied=True are mutually exclusive",
+                    "rule": "!(self.conditions.exists(c, c.type == 'Approved' && c.status == 'True') && self.conditions.exists(c, c.type == 'Denied' && c.status == 'True'))"
+                  },
+                  {
+                    "message": "plan decisions are terminal",
+                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+                  },
+                  {
+                    "message": "decision identity is write-once",
+                    "rule": "!has(oldSelf.decidedBy) || (has(self.decidedBy) && self.decidedBy == oldSelf.decidedBy)"
+                  },
+                  {
+                    "message": "a terminal plan decision and decidedBy identity must be recorded together",
+                    "rule": "self.conditions.exists(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == has(self.decidedBy)"
+                  }
+                ]
               }
             },
             "required": [

--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -321,6 +321,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 16,
                     "type": "array"
                   },
                   "decidedBy": {
@@ -461,7 +462,7 @@
                   },
                   {
                     "message": "plan decisions are terminal",
-                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) == self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) || oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0"
                   },
                   {
                     "message": "decision identity is write-once",

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -190,12 +190,6 @@ impl PostgresPolicySpec {
 // Well-known annotations and labels
 // ---------------------------------------------------------------------------
 
-/// Annotation key used to approve a `PostgresPolicyPlan`.
-pub const PLAN_APPROVED_ANNOTATION: &str = "pgroles.io/approved";
-
-/// Annotation key used to reject a `PostgresPolicyPlan`.
-pub const PLAN_REJECTED_ANNOTATION: &str = "pgroles.io/rejected";
-
 /// Annotation key used to request an immediate `PostgresPolicy` reconcile.
 pub const REQUESTED_RECONCILE_ANNOTATION: &str = "reconcile.pgroles.io/requestedAt";
 
@@ -1021,15 +1015,43 @@ pub struct PolicyPlanRef {
 }
 
 /// Status of a `PostgresPolicyPlan` resource.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+///
+/// The decision rules below are the same grammar `EphemeralAccessRequest`
+/// uses: a decision is terminal, `Approved` and `Denied` cannot both be true,
+/// and the deciding identity is recorded in the same admitted write. What CEL
+/// cannot do is check *who* is writing — see [`DecisionActor`].
+#[derive(KubeSchema, Debug, Clone, Default, Serialize, Deserialize)]
+#[x_kube(
+    validation = Rule::new(
+        "!(self.conditions.exists(c, c.type == 'Approved' && c.status == 'True') && self.conditions.exists(c, c.type == 'Denied' && c.status == 'True'))"
+    ).message("Approved=True and Denied=True are mutually exclusive"),
+    validation = Rule::new(
+        "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+    ).message("plan decisions are terminal"),
+    validation = Rule::new(
+        "!has(oldSelf.decidedBy) || (has(self.decidedBy) && self.decidedBy == oldSelf.decidedBy)"
+    ).message("decision identity is write-once"),
+    validation = Rule::new(
+        "self.conditions.exists(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == has(self.decidedBy)"
+    ).message("a terminal plan decision and decidedBy identity must be recorded together")
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PostgresPolicyPlanStatus {
     /// Phase: Pending, Approved, Applying, Applied, Failed, Superseded.
     #[serde(default)]
     pub phase: PlanPhase,
-    /// Standard conditions: Computed, Approved, Applied.
+    /// Standard conditions: Computed, Applied, and the terminal decision
+    /// conditions `Approved` / `Denied`.
     #[serde(default)]
     pub conditions: Vec<PolicyCondition>,
+    /// Kubernetes identity which approved or denied this plan.
+    ///
+    /// Written in the same status update as the terminal decision, and
+    /// write-once thereafter. The supplied Kyverno reference policy overwrites
+    /// it from authenticated admission `userInfo`; without that admission layer
+    /// it is an assertion by whoever wrote the status, not a verified identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decided_by: Option<DecisionActor>,
     /// Summary of changes in this plan.
     #[serde(default)]
     pub change_summary: Option<ChangeSummary>,
@@ -1271,7 +1293,7 @@ pub struct EphemeralAccessRequestSpec {
     pub subject: EphemeralAccessSubject,
     /// Kubernetes identity which created the request. The supplied Kyverno
     /// reference policy overwrites this from authenticated admission `userInfo`.
-    pub requested_by: EphemeralAccessActor,
+    pub requested_by: DecisionActor,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(max = 64), regex(pattern = r"^([0-9]+[smh])+$"))]
     pub requested_duration: Option<String>,
@@ -1286,14 +1308,19 @@ pub struct EphemeralAccessSubject {
     pub role: String,
 }
 
-/// Authenticated Kubernetes identity associated with an access action.
+/// Authenticated Kubernetes identity associated with a decision or request.
 ///
-/// The supplied Kyverno reference policy replaces these values from the
-/// admission request's `userInfo`. Without admission enforcement they are
-/// assertions by the trusted request or approval broker.
+/// Shared by `EphemeralAccessRequest` and `PostgresPolicyPlan` so both
+/// lifecycles record who decided in one vocabulary.
+///
+/// **This is only as trustworthy as the admission layer.** CEL validation
+/// cannot see `request.userInfo`, so the API server alone cannot tell a real
+/// identity from an asserted one. The supplied Kyverno reference policy
+/// overwrites these values from the admission request's authenticated
+/// `userInfo`; without it, they are whatever the client claimed.
 #[derive(KubeSchema, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct EphemeralAccessActor {
+pub struct DecisionActor {
     #[schemars(length(min = 1, max = 512))]
     pub username: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1338,7 +1365,7 @@ pub struct EphemeralAccessRequestStatus {
     /// Kyverno reference policy overwrites this from authenticated admission
     /// `userInfo` in the same status update as the terminal decision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub decided_by: Option<EphemeralAccessActor>,
+    pub decided_by: Option<DecisionActor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(max = 64))]
     pub approval_expires_at: Option<String>,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1025,8 +1025,13 @@ pub struct PolicyPlanRef {
     validation = Rule::new(
         "!(self.conditions.exists(c, c.type == 'Approved' && c.status == 'True') && self.conditions.exists(c, c.type == 'Denied' && c.status == 'True'))"
     ).message("Approved=True and Denied=True are mutually exclusive"),
+    // Compares the *decision types* that are true, not whole condition
+    // objects. The operator rewrites this array on every status write, so
+    // comparing objects would reject a later write that only refreshed a
+    // timestamp or message — while the decision itself was unchanged. What
+    // must not change is which decisions are true.
     validation = Rule::new(
-        "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+        "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) == self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) || oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0"
     ).message("plan decisions are terminal"),
     validation = Rule::new(
         "!has(oldSelf.decidedBy) || (has(self.decidedBy) && self.decidedBy == oldSelf.decidedBy)"
@@ -1043,6 +1048,7 @@ pub struct PostgresPolicyPlanStatus {
     /// Standard conditions: Computed, Applied, and the terminal decision
     /// conditions `Approved` / `Denied`.
     #[serde(default)]
+    #[schemars(length(max = 16))]
     pub conditions: Vec<PolicyCondition>,
     /// Kubernetes identity which approved or denied this plan.
     ///

--- a/crates/pgroles-operator/src/ephemeral.rs
+++ b/crates/pgroles-operator/src/ephemeral.rs
@@ -2383,7 +2383,7 @@ mod tests {
                 subject: crate::crd::EphemeralAccessSubject {
                     role: "alice".into(),
                 },
-                requested_by: crate::crd::EphemeralAccessActor {
+                requested_by: crate::crd::DecisionActor {
                     username: "requester@example.com".into(),
                     uid: Some("requester-uid".into()),
                     groups: vec!["developers".into()],

--- a/crates/pgroles-operator/src/main.rs
+++ b/crates/pgroles-operator/src/main.rs
@@ -30,21 +30,20 @@ use pgroles_operator::observability::{
 use pgroles_operator::reconciler::{error_policy, reconcile};
 use pgroles_operator::request_index::RequestIndex;
 
-/// Hash for plan annotation changes — triggers parent policy reconciliation
-/// when approval/rejection annotations are added or modified.
-fn plan_annotation_hash(plan: &PostgresPolicyPlan) -> Option<u64> {
+/// Hash for plan decision changes — triggers parent policy reconciliation when
+/// a reviewer records a decision, or the operator moves the plan's phase.
+///
+/// Decisions live in the status subresource, so this hashes the terminal
+/// decision conditions rather than annotations.
+fn plan_decision_hash(plan: &PostgresPolicyPlan) -> Option<u64> {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    // Hash the approval-related annotations so we trigger on changes.
-    if let Some(annotations) = &plan.metadata.annotations {
-        annotations
-            .get(pgroles_operator::crd::PLAN_APPROVED_ANNOTATION)
-            .hash(&mut hasher);
-        annotations
-            .get(pgroles_operator::crd::PLAN_REJECTED_ANNOTATION)
-            .hash(&mut hasher);
-    }
-    // Also hash the plan's status phase to detect operator-driven transitions.
     if let Some(status) = &plan.status {
+        for condition in &status.conditions {
+            if condition.condition_type == "Approved" || condition.condition_type == "Denied" {
+                condition.condition_type.hash(&mut hasher);
+                condition.status.hash(&mut hasher);
+            }
+        }
         format!("{}", status.phase).hash(&mut hasher);
     }
     Some(hasher.finish())
@@ -183,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
     let plan_triggers = watcher(plans, watcher::Config::default())
         .default_backoff()
         .touched_objects()
-        .predicate_filter(plan_annotation_hash, Default::default())
+        .predicate_filter(plan_decision_hash, Default::default())
         .filter_map(|plan| async move { plan.ok() })
         .flat_map(move |plan| {
             let policy_store = plan_policy_store.clone();

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -21,9 +21,8 @@ use tracing::info;
 
 use crate::crd::{
     ChangeSummary, CrdReconciliationMode, LABEL_DATABASE_IDENTITY, LABEL_PLAN, LABEL_POLICY,
-    PLAN_APPROVED_ANNOTATION, PLAN_REJECTED_ANNOTATION, PlanPhase, PlanReference, PolicyCondition,
-    PolicyPlanRef, PostgresPolicy, PostgresPolicyPlan, PostgresPolicyPlanSpec,
-    PostgresPolicyPlanStatus, SqlCompression, SqlRef,
+    PlanPhase, PlanReference, PolicyCondition, PolicyPlanRef, PostgresPolicy, PostgresPolicyPlan,
+    PostgresPolicyPlanSpec, PostgresPolicyPlanStatus, SqlCompression, SqlRef,
 };
 use crate::k8s_names::{LabelValue, truncate_name_prefix};
 use crate::reconciler::ReconcileError;
@@ -138,28 +137,38 @@ pub enum PlanApprovalState {
     Rejected,
 }
 
-/// Check the approval state of a plan by inspecting its annotations.
+/// Identity recorded as the decider when `approval: auto` lets the operator
+/// approve its own plan. It is not a Kubernetes user; it names the mechanism so
+/// an audit trail never shows an unattributed approval.
+pub const AUTO_APPROVAL_ACTOR: &str = "system:pgroles-operator(auto-approval)";
+
+/// Read the decision recorded on a plan.
 ///
-/// Rejection takes priority over approval: if both annotations are set,
-/// the plan is considered rejected.
+/// The decision lives in the status subresource as a terminal `Approved` or
+/// `Denied` condition, alongside the `decidedBy` identity written in the same
+/// admitted update. It replaced the `pgroles.io/approved` annotation, which any
+/// holder of patch on the object could set, unset, or forge without trace.
+///
+/// `Denied` wins over `Approved` if both are somehow present. CEL rejects that
+/// combination at admission, so reaching it means the rules were bypassed —
+/// refusing to execute is the fail-closed reading.
 pub fn check_plan_approval(plan: &PostgresPolicyPlan) -> PlanApprovalState {
-    let annotations = plan.metadata.annotations.as_ref();
+    let Some(status) = plan.status.as_ref() else {
+        return PlanApprovalState::Pending;
+    };
 
-    let rejected = annotations
-        .and_then(|a| a.get(PLAN_REJECTED_ANNOTATION))
-        .map(|v| v == "true")
-        .unwrap_or(false);
+    let decided = |condition_type: &str| {
+        status
+            .conditions
+            .iter()
+            .any(|c| c.condition_type == condition_type && c.status == "True")
+    };
 
-    if rejected {
+    if decided("Denied") {
         return PlanApprovalState::Rejected;
     }
 
-    let approved = annotations
-        .and_then(|a| a.get(PLAN_APPROVED_ANNOTATION))
-        .map(|v| v == "true")
-        .unwrap_or(false);
-
-    if approved {
+    if decided("Approved") {
         return PlanApprovalState::Approved;
     }
 
@@ -407,6 +416,9 @@ pub async fn create_or_update_plan(
     };
     let plan_status = PostgresPolicyPlanStatus {
         phase: PlanPhase::Pending,
+        // No decision yet, so no deciding identity. The CEL rule pairing the
+        // two means a plan is never born with one without the other.
+        decided_by: None,
         conditions: vec![
             PolicyCondition {
                 condition_type: "Computed".to_string(),
@@ -1545,6 +1557,16 @@ pub async fn mark_plan_approved(
     let mut status = plan.status.clone().unwrap_or_default();
     status.phase = PlanPhase::Approved;
     set_plan_condition(&mut status.conditions, "Approved", "True", reason, message);
+    // Under `approval: auto` the operator itself is the decider, and the CEL
+    // rule requires the identity in the same write as the decision. Naming the
+    // operator is also the honest record: no human reviewed this.
+    if status.decided_by.is_none() {
+        status.decided_by = Some(crate::crd::DecisionActor {
+            username: AUTO_APPROVAL_ACTOR.to_string(),
+            uid: None,
+            groups: Vec::new(),
+        });
+    }
 
     let patch = serde_json::json!({ "status": status });
     plans_api
@@ -1569,12 +1591,14 @@ pub async fn mark_plan_rejected(
 
     let mut status = plan.status.clone().unwrap_or_default();
     status.phase = PlanPhase::Rejected;
+    // The reviewer's `Denied=True` is the decision and is terminal; this only
+    // records that the operator has observed it and moved the plan's phase.
     set_plan_condition(
         &mut status.conditions,
         "Approved",
         "False",
-        "Rejected",
-        "Plan rejected via annotation",
+        "DeniedByReviewer",
+        "Plan denied by a reviewer",
     );
 
     let patch = serde_json::json!({ "status": status });
@@ -1932,6 +1956,37 @@ mod tests {
         );
     }
 
+    /// Build a plan carrying the given terminal decision conditions.
+    ///
+    /// `decisions` are `(condition_type, status)` pairs written exactly as a
+    /// reviewer's status patch would leave them.
+    fn test_plan_with_decisions(
+        name: &str,
+        phase: PlanPhase,
+        decisions: &[(&str, &str)],
+    ) -> PostgresPolicyPlan {
+        let mut plan = test_plan(name, phase, None);
+        let status = plan.status.as_mut().expect("status");
+        status.conditions = decisions
+            .iter()
+            .map(|(condition_type, condition_status)| PolicyCondition {
+                condition_type: (*condition_type).to_string(),
+                status: (*condition_status).to_string(),
+                reason: Some("DecidedByReviewer".to_string()),
+                message: None,
+                last_transition_time: Some(crate::crd::now_rfc3339()),
+            })
+            .collect();
+        if decisions.iter().any(|(_, s)| *s == "True") {
+            status.decided_by = Some(crate::crd::DecisionActor {
+                username: "reviewer@example.com".to_string(),
+                uid: Some("uid-1".to_string()),
+                groups: vec!["platform".to_string()],
+            });
+        }
+        plan
+    }
+
     fn test_plan(
         name: &str,
         phase: PlanPhase,
@@ -1962,41 +2017,68 @@ mod tests {
     }
 
     #[test]
-    fn check_plan_approval_pending_when_no_annotations() {
+    fn a_plan_with_no_recorded_decision_is_pending() {
         let plan = test_plan("plan-1", PlanPhase::Pending, None);
         assert_eq!(check_plan_approval(&plan), PlanApprovalState::Pending);
+
+        // A plan with no status at all — freshly created, status not yet
+        // written — must also read as undecided rather than panicking.
+        let mut statusless = test_plan("plan-2", PlanPhase::Pending, None);
+        statusless.status = None;
+        assert_eq!(check_plan_approval(&statusless), PlanApprovalState::Pending);
     }
 
     #[test]
-    fn check_plan_approval_approved_with_annotation() {
-        let annotations =
-            BTreeMap::from([(PLAN_APPROVED_ANNOTATION.to_string(), "true".to_string())]);
-        let plan = test_plan("plan-1", PlanPhase::Pending, Some(annotations));
-        assert_eq!(check_plan_approval(&plan), PlanApprovalState::Approved);
+    fn a_decision_is_read_from_the_status_conditions() {
+        let approved =
+            test_plan_with_decisions("plan-1", PlanPhase::Pending, &[("Approved", "True")]);
+        assert_eq!(check_plan_approval(&approved), PlanApprovalState::Approved);
+
+        let denied = test_plan_with_decisions("plan-1", PlanPhase::Pending, &[("Denied", "True")]);
+        assert_eq!(check_plan_approval(&denied), PlanApprovalState::Rejected);
     }
 
+    /// A plan is created carrying `Approved=False`, which is the *absence* of a
+    /// decision, not a denial. Reading it as either decision would auto-execute
+    /// or auto-reject every freshly created plan.
     #[test]
-    fn check_plan_approval_rejected_with_annotation() {
-        let annotations =
-            BTreeMap::from([(PLAN_REJECTED_ANNOTATION.to_string(), "true".to_string())]);
-        let plan = test_plan("plan-1", PlanPhase::Pending, Some(annotations));
+    fn a_false_decision_condition_is_not_a_decision() {
+        for conditions in [
+            &[("Approved", "False")][..],
+            &[("Denied", "False")][..],
+            &[("Approved", "False"), ("Denied", "False")][..],
+        ] {
+            let plan = test_plan_with_decisions("plan-1", PlanPhase::Pending, conditions);
+            assert_eq!(
+                check_plan_approval(&plan),
+                PlanApprovalState::Pending,
+                "conditions {conditions:?} must not read as a decision"
+            );
+        }
+    }
+
+    /// CEL rejects Approved=True alongside Denied=True at admission, so this
+    /// state is only reachable if the rules were bypassed. Refusing to execute
+    /// is the fail-closed reading.
+    #[test]
+    fn a_contradictory_decision_never_executes() {
+        let plan = test_plan_with_decisions(
+            "plan-1",
+            PlanPhase::Pending,
+            &[("Approved", "True"), ("Denied", "True")],
+        );
         assert_eq!(check_plan_approval(&plan), PlanApprovalState::Rejected);
     }
 
+    /// The decision no longer lives in annotations. A plan annotated the old
+    /// way carries no authority at all — otherwise removing the mechanism
+    /// would have left a silent bypass behind.
     #[test]
-    fn check_plan_approval_rejected_wins_over_approved() {
+    fn the_retired_approval_annotation_grants_nothing() {
         let annotations = BTreeMap::from([
-            (PLAN_APPROVED_ANNOTATION.to_string(), "true".to_string()),
-            (PLAN_REJECTED_ANNOTATION.to_string(), "true".to_string()),
+            ("pgroles.io/approved".to_string(), "true".to_string()),
+            ("pgroles.io/rejected".to_string(), "true".to_string()),
         ]);
-        let plan = test_plan("plan-1", PlanPhase::Pending, Some(annotations));
-        assert_eq!(check_plan_approval(&plan), PlanApprovalState::Rejected);
-    }
-
-    #[test]
-    fn check_plan_approval_non_true_value_is_pending() {
-        let annotations =
-            BTreeMap::from([(PLAN_APPROVED_ANNOTATION.to_string(), "false".to_string())]);
         let plan = test_plan("plan-1", PlanPhase::Pending, Some(annotations));
         assert_eq!(check_plan_approval(&plan), PlanApprovalState::Pending);
     }

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1589,19 +1589,11 @@ pub async fn mark_plan_rejected(
     let plan_name = plan.name_any();
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
 
-    let mut status = plan.status.clone().unwrap_or_default();
-    status.phase = PlanPhase::Rejected;
-    // The reviewer's `Denied=True` is the decision and is terminal; this only
-    // records that the operator has observed it and moved the plan's phase.
-    set_plan_condition(
-        &mut status.conditions,
-        "Approved",
-        "False",
-        "DeniedByReviewer",
-        "Plan denied by a reviewer",
-    );
-
-    let patch = serde_json::json!({ "status": status });
+    // Patch the phase alone. The reviewer's `Denied=True` is the decision and
+    // is terminal, so there is nothing here for the operator to add to the
+    // conditions — and resending the whole array from a watch-backed read
+    // could drop a decision that landed after that read.
+    let patch = serde_json::json!({ "status": { "phase": PlanPhase::Rejected } });
     plans_api
         .patch_status(
             &plan_name,

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1393,14 +1393,13 @@ fn set_plan_condition(
         message: Some(message.to_string()),
         last_transition_time: transition_time,
     };
-    if let Some(existing) = conditions
-        .iter_mut()
-        .find(|c| c.condition_type == condition_type)
-    {
-        *existing = condition;
-    } else {
-        conditions.push(condition);
-    }
+    // Collapse to exactly one entry per condition type. Replacing only the
+    // first match would leave a duplicate in place, and a second `Approved`
+    // that this never touches makes the CRD's terminality rule see the
+    // decision set grow — rejecting the operator's own writes and stranding
+    // the plan. A malformed status should not be able to do that.
+    conditions.retain(|c| c.condition_type != condition_type);
+    conditions.push(condition);
 }
 
 /// Update the parent policy's `current_plan_ref` in status.
@@ -2897,6 +2896,49 @@ mod tests {
             decide_approved_plan(Some(&approved_empty), &empty_digest, false),
             ApprovedPlanDecision::Execute,
         );
+    }
+
+    /// A status carrying a duplicate condition type must collapse to one.
+    ///
+    /// Replacing only the first match left the second in place, and a second
+    /// `Approved=True` makes the terminality rule see the true-decision set
+    /// grow — which rejects the operator's own write and strands the plan.
+    #[test]
+    fn setting_a_condition_leaves_exactly_one_of_that_type() {
+        let mut conditions = vec![
+            PolicyCondition {
+                condition_type: "Computed".to_string(),
+                status: "True".to_string(),
+                reason: None,
+                message: None,
+                last_transition_time: None,
+            },
+            PolicyCondition {
+                condition_type: "Approved".to_string(),
+                status: "False".to_string(),
+                reason: Some("PendingApproval".to_string()),
+                message: None,
+                last_transition_time: None,
+            },
+            PolicyCondition {
+                condition_type: "Approved".to_string(),
+                status: "True".to_string(),
+                reason: Some("ApprovedByReviewer".to_string()),
+                message: None,
+                last_transition_time: None,
+            },
+        ];
+
+        set_plan_condition(&mut conditions, "Approved", "True", "Reason", "Message");
+
+        let approved: Vec<_> = conditions
+            .iter()
+            .filter(|c| c.condition_type == "Approved")
+            .collect();
+        assert_eq!(approved.len(), 1, "duplicate Approved conditions survived");
+        assert_eq!(approved[0].status, "True");
+        // Unrelated conditions are untouched.
+        assert!(conditions.iter().any(|c| c.condition_type == "Computed"));
     }
 
     /// Planning must never persist password material, in any field.

--- a/crates/pgroles-operator/src/request_index.rs
+++ b/crates/pgroles-operator/src/request_index.rs
@@ -261,7 +261,7 @@ impl RequestIndex {
 mod tests {
     use super::*;
     use crate::crd::{
-        EphemeralAccessActor, EphemeralAccessRequestSpec, EphemeralAccessRequestStatus,
+        DecisionActor, EphemeralAccessRequestSpec, EphemeralAccessRequestStatus,
         EphemeralAccessSubject, LocalObjectReference, ResolvedEphemeralAccess,
     };
 
@@ -280,7 +280,7 @@ mod tests {
                 subject: EphemeralAccessSubject {
                     role: "alice".into(),
                 },
-                requested_by: EphemeralAccessActor {
+                requested_by: DecisionActor {
                     username: "user".into(),
                     uid: None,
                     groups: vec![],

--- a/docs/src/pages/docs/operator-plan-approval.md
+++ b/docs/src/pages/docs/operator-plan-approval.md
@@ -7,12 +7,20 @@ Seeing what the operator would do before it does it. {% .lead %}
 
 ---
 
-{% callout type="warning" title="Design preview" %}
-This page documents the target design from
-[#173](https://github.com/hardbyte/pgroles/issues/173) ahead of implementation:
-`mode: observe` (renamed from `plan`), the semantic change digest, write-once
-plan decisions, and tiered target identity. Released behaviour still uses
-`mode: plan`, approval annotations, and SQL-hash matching.
+{% callout type="warning" title="Partly a design preview" %}
+Shipped and described accurately below: the semantic change digest as approval
+identity, revalidation of pending plans, and write-once plan decisions with
+`decidedBy` — including the annotation removal.
+
+**Not yet built**, though this page describes them: `mode: observe` (today it is
+still `mode: plan`), tiered target identity and `requirePhysicalIdentity`
+([#180](https://github.com/hardbyte/pgroles/issues/180)), deferring generated
+password Secrets until after approval
+([#181](https://github.com/hardbyte/pgroles/issues/181)), the
+`PostgresPolicyCandidate` CRD, and every `pgroles plan ...` /
+`pgroles candidate ...` command shown here — the CLI has no such subcommands
+yet. Use `kubectl` for anything you need to do today; see the
+[quick start](/docs/operator-quick-start) for the exact commands.
 {% /callout %}
 
 ## Observe mode
@@ -145,9 +153,12 @@ changed once written. ("Rejected" is the phase; `Denied` is the condition —
 they always travel together.) A candidate whose plan is denied is terminal
 too, reporting `Superseded=True, reason=PlanDenied`.
 
-The CLI patches the plan's status subresource; raw `kubectl patch
---subresource=status` works identically. The approval annotations from
-earlier releases are removed.
+Decisions are written to the plan's status subresource with `kubectl patch
+--subresource=status` (the CLI wrapper is not built yet). The
+`pgroles.io/approved` and `pgroles.io/rejected` annotations that earlier
+releases used have been removed outright: setting them now does nothing at all,
+which is deliberate — a retired approval mechanism that still worked would be a
+silent bypass of everything below.
 
 The trust model has two layers, and both matter:
 

--- a/docs/src/pages/docs/operator-quick-start.md
+++ b/docs/src/pages/docs/operator-quick-start.md
@@ -143,11 +143,23 @@ produce either.
 
 ## 5. Approve and verify
 
-Approve exactly the plan you reviewed:
+Approve exactly the plan you reviewed. The decision is a terminal condition on
+the plan's status, written together with the identity that decided — the two
+must land in one write, and neither can be changed afterwards:
 
 ```bash
-kubectl annotate pgplan "$PLAN" --namespace "$NAMESPACE" \
-  pgroles.io/approved=true --overwrite
+kubectl patch pgplan "$PLAN" --namespace "$NAMESPACE" \
+  --subresource=status --type=merge -p '{
+    "status": {
+      "conditions": [{
+        "type": "Approved", "status": "True",
+        "reason": "ApprovedByReviewer",
+        "message": "reviewed change summary",
+        "lastTransitionTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+      }],
+      "decidedBy": {"username": "'"$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}')"'"}
+    }
+  }'
 
 kubectl wait --namespace "$NAMESPACE" \
   --for=jsonpath='{.status.phase}'=Applied "pgplan/$PLAN" \
@@ -160,6 +172,41 @@ kubectl get pgplan "$PLAN" --namespace "$NAMESPACE"
 The policy should now show `DRIFT=False`; the plan phase should be `Applied`.
 The operator re-inspects and re-renders before execution, so it will supersede
 an approved plan rather than run it if the database diff changed during review.
+
+To reject a plan instead, write `Denied` in place of `Approved`. The operator
+moves the plan to `Rejected` and creates a fresh plan on the next reconcile:
+
+```bash
+kubectl patch pgplan "$PLAN" --namespace "$NAMESPACE" \
+  --subresource=status --type=merge -p '{
+    "status": {
+      "conditions": [{
+        "type": "Denied", "status": "True",
+        "reason": "DeniedByReviewer",
+        "message": "not approving this change",
+        "lastTransitionTime": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+      }],
+      "decidedBy": {"username": "'"$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}')"'"}
+    }
+  }'
+```
+
+A decision is terminal: it cannot be changed, reversed, or paired with the
+opposite decision. Iterating means a new plan, not an edited decision.
+
+{% callout type="warning" title="decidedBy is only as good as your admission layer" %}
+The CRD's validation rules make a decision terminal and force it to carry a
+`decidedBy`, but Kubernetes CEL cannot see the authenticated user, so the API
+server cannot check that `decidedBy` names the account that actually wrote it —
+above, you are typing your own username into the field.
+
+Install `k8s/security/plan-decision-kyverno.yaml` to make it verified. It
+overwrites `decidedBy` from the authenticated admission request and requires
+the `approve` verb on the parent `PostgresPolicy`, so patching a plan's status
+is no longer by itself authority to approve a database change. Without it, any
+account that can patch `postgrespolicyplans/status` can approve, under any name
+it chooses.
+{% /callout %}
 
 ## 6. Make a second change
 

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -180,7 +180,7 @@
                 "type": "object"
               },
               "status": {
-                "description": "Status of a `PostgresPolicyPlan` resource.",
+                "description": "Status of a `PostgresPolicyPlan` resource.\n\nThe decision rules below are the same grammar `EphemeralAccessRequest`\nuses: a decision is terminal, `Approved` and `Denied` cannot both be true,\nand the deciding identity is recorded in the same admitted write. What CEL\ncannot do is check *who* is writing — see [`DecisionActor`].",
                 "nullable": true,
                 "properties": {
                   "appliedAt": {
@@ -287,7 +287,7 @@
                   },
                   "conditions": {
                     "default": [],
-                    "description": "Standard conditions: Computed, Approved, Applied.",
+                    "description": "Standard conditions: Computed, Applied, and the terminal decision\nconditions `Approved` / `Denied`.",
                     "items": {
                       "description": "A condition on the `PostgresPolicy` resource.",
                       "properties": {
@@ -322,6 +322,36 @@
                       "type": "object"
                     },
                     "type": "array"
+                  },
+                  "decidedBy": {
+                    "description": "Kubernetes identity which approved or denied this plan.\n\nWritten in the same status update as the terminal decision, and\nwrite-once thereafter. The supplied Kyverno reference policy overwrites\nit from authenticated admission `userInfo`; without that admission layer\nit is an assertion by whoever wrote the status, not a verified identity.",
+                    "nullable": true,
+                    "properties": {
+                      "groups": {
+                        "default": [],
+                        "items": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "maxItems": 64,
+                        "type": "array"
+                      },
+                      "uid": {
+                        "maxLength": 128,
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "username": {
+                        "maxLength": 512,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "username"
+                    ],
+                    "type": "object"
                   },
                   "failedAt": {
                     "description": "Timestamp when the plan entered Failed phase (for dedup window).",
@@ -423,7 +453,25 @@
                     "type": "boolean"
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "Approved=True and Denied=True are mutually exclusive",
+                    "rule": "!(self.conditions.exists(c, c.type == 'Approved' && c.status == 'True') && self.conditions.exists(c, c.type == 'Denied' && c.status == 'True'))"
+                  },
+                  {
+                    "message": "plan decisions are terminal",
+                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+                  },
+                  {
+                    "message": "decision identity is write-once",
+                    "rule": "!has(oldSelf.decidedBy) || (has(self.decidedBy) && self.decidedBy == oldSelf.decidedBy)"
+                  },
+                  {
+                    "message": "a terminal plan decision and decidedBy identity must be recorded together",
+                    "rule": "self.conditions.exists(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == has(self.decidedBy)"
+                  }
+                ]
               }
             },
             "required": [

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -321,6 +321,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 16,
                     "type": "array"
                   },
                   "decidedBy": {
@@ -461,7 +462,7 @@
                   },
                   {
                     "message": "plan decisions are terminal",
-                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0 || self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True') == oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True')"
+                    "rule": "oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) == self.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').map(c, c.type) || oldSelf.conditions.filter(c, (c.type == 'Approved' || c.type == 'Denied') && c.status == 'True').size() == 0"
                   },
                   {
                     "message": "decision identity is write-once",

--- a/k8s/security/plan-decision-kyverno.yaml
+++ b/k8s/security/plan-decision-kyverno.yaml
@@ -1,0 +1,146 @@
+# Admission policy for PostgresPolicyPlan decisions.
+#
+# The CRD's CEL rules make a decision terminal, mutually exclusive, and paired
+# with a `decidedBy` identity — but CEL cannot see `request.userInfo`, so the
+# API server alone cannot tell a real approver from a client that simply typed
+# a username into the field. This policy is what closes that gap:
+#
+#   1. it overwrites `decidedBy` from the authenticated admission request, so
+#      the recorded identity is the one the API server verified, and
+#   2. it requires the logical `approve` verb on the parent PostgresPolicy, so
+#      being able to patch a plan's status is not by itself authority to
+#      approve database changes.
+#
+# Without this policy installed, `decidedBy` is an assertion, and anyone with
+# patch on plans/status can approve. Deployments that need separation of duties
+# must install it. This is stated in the operator docs as a deployment
+# requirement, not an optional hardening step.
+#
+# Mirrors k8s/security/ephemeral-access-kyverno.yaml so both decision
+# lifecycles are enforced the same way.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pgroles-plan-decision-kyverno-reports
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups: [pgroles.io]
+    resources:
+      - postgrespolicies
+      - postgrespolicyplans
+      - postgrespolicyplans/status
+    verbs: [get, list, watch]
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pgroles-plan-decision-authorization
+  labels:
+    app.kubernetes.io/name: pgroles-operator
+    app.kubernetes.io/component: admission-policy
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    # Record the authenticated identity in the same status mutation as the
+    # first terminal decision. The CRD's transition rules make it write-once
+    # once admission has persisted it.
+    - name: record-authenticated-decision-maker
+      match:
+        any:
+          - resources:
+              kinds: [pgroles.io/v1alpha1/PostgresPolicyPlan/status]
+              operations: [UPDATE]
+      preconditions:
+        any:
+          - key: >-
+              {{ to_string(request.object.status.conditions[?type == 'Approved'] || `[]`) }}
+            operator: NotEquals
+            value: >-
+              {{ to_string(request.oldObject.status.conditions[?type == 'Approved'] || `[]`) }}
+          - key: >-
+              {{ to_string(request.object.status.conditions[?type == 'Denied'] || `[]`) }}
+            operator: NotEquals
+            value: >-
+              {{ to_string(request.oldObject.status.conditions[?type == 'Denied'] || `[]`) }}
+      mutate:
+        patchStrategicMerge:
+          status:
+            decidedBy:
+              username: "{{ request.userInfo.username }}"
+              uid: "{{ request.userInfo.uid || '' }}"
+              groups: "{{ request.userInfo.groups }}"
+
+    # Deciding a plan requires the logical `approve` verb on the parent policy.
+    # Patch access to plans/status is shared with the operator and is not, on
+    # its own, authority to approve a change to the database.
+    - name: require-approve-on-decision-change
+      match:
+        any:
+          - resources:
+              kinds: [pgroles.io/v1alpha1/PostgresPolicyPlan/status]
+              operations: [UPDATE]
+      preconditions:
+        any:
+          - key: >-
+              {{ to_string(request.object.status.conditions[?type == 'Approved'] || `[]`) }}
+            operator: NotEquals
+            value: >-
+              {{ to_string(request.oldObject.status.conditions[?type == 'Approved'] || `[]`) }}
+          - key: >-
+              {{ to_string(request.object.status.conditions[?type == 'Denied'] || `[]`) }}
+            operator: NotEquals
+            value: >-
+              {{ to_string(request.oldObject.status.conditions[?type == 'Denied'] || `[]`) }}
+      context:
+        - name: subjectaccessreview
+          apiCall:
+            urlPath: /apis/authorization.k8s.io/v1/subjectaccessreviews
+            method: POST
+            data:
+              - key: kind
+                value: SubjectAccessReview
+              - key: apiVersion
+                value: authorization.k8s.io/v1
+              - key: spec
+                value:
+                  resourceAttributes:
+                    group: pgroles.io
+                    resource: postgrespolicies
+                    namespace: "{{ request.namespace }}"
+                    name: "{{ request.object.spec.policyRef.name }}"
+                    verb: approve
+                  user: "{{ request.userInfo.username }}"
+                  groups: "{{ request.userInfo.groups }}"
+      validate:
+        message: >-
+          changing Approved or Denied requires the approve verb on the parent
+          PostgresPolicy
+        deny:
+          conditions:
+            any:
+              - key: "{{ subjectaccessreview.status.allowed }}"
+                operator: NotEquals
+                value: true
+---
+# Grant the logical `approve` verb to plan reviewers. Bind this to the humans
+# or groups permitted to authorise database changes; it is deliberately
+# separate from write access to PostgresPolicy itself, so proposing a change
+# and approving one are distinct capabilities.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pgroles-plan-approver
+  labels:
+    app.kubernetes.io/name: pgroles-operator
+rules:
+  - apiGroups: [pgroles.io]
+    resources: [postgrespolicies]
+    verbs: [approve]
+  - apiGroups: [pgroles.io]
+    resources: [postgrespolicyplans]
+    verbs: [get, list, watch]
+  - apiGroups: [pgroles.io]
+    resources: [postgrespolicyplans/status]
+    verbs: [patch, update]

--- a/k8s/security/plan-decision-kyverno.yaml
+++ b/k8s/security/plan-decision-kyverno.yaml
@@ -32,6 +32,23 @@ rules:
       - postgrespolicyplans/status
     verbs: [get, list, watch]
 ---
+# The `approve`-verb check below posts a SubjectAccessReview using the Kyverno
+# admission controller's own credentials. Without this it cannot, and because
+# the policy is enforcing, a failed context lookup blocks every decision write.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pgroles-plan-decision-kyverno-sar
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+  - apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]
+  - apiGroups: [pgroles.io]
+    resources: [postgrespolicies, postgrespolicyplans]
+    verbs: [get, list, watch]
+---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -53,17 +70,25 @@ spec:
               kinds: [pgroles.io/v1alpha1/PostgresPolicyPlan/status]
               operations: [UPDATE]
       preconditions:
-        any:
+        all:
+          # Only a *newly true* decision counts. The operator's own writes —
+          # creating a plan with Approved=False, recording a rejection it
+          # observed, auto-approving under `approval: auto` — must not be
+          # treated as a reviewer decision, or the operator would need the
+          # approve verb and would have its own decidedBy overwritten.
           - key: >-
-              {{ to_string(request.object.status.conditions[?type == 'Approved'] || `[]`) }}
-            operator: NotEquals
+              {{ length(request.object.status.conditions[?(type == 'Approved' || type == 'Denied') && status == 'True']) }}
+            operator: GreaterThan
             value: >-
-              {{ to_string(request.oldObject.status.conditions[?type == 'Approved'] || `[]`) }}
-          - key: >-
-              {{ to_string(request.object.status.conditions[?type == 'Denied'] || `[]`) }}
+              {{ length(request.oldObject.status.conditions[?(type == 'Approved' || type == 'Denied') && status == 'True'] || `[]`) }}
+          # EDIT THIS if you install the operator under a different namespace
+          # or ServiceAccount name (Helm: `operator.serviceAccount.name`,
+          # `--namespace`). Kyverno cannot resolve it for you, and getting it
+          # wrong means the operator's own status writes are treated as
+          # reviewer decisions and rejected.
+          - key: "{{ request.userInfo.username }}"
             operator: NotEquals
-            value: >-
-              {{ to_string(request.oldObject.status.conditions[?type == 'Denied'] || `[]`) }}
+            value: "system:serviceaccount:pgroles-system:pgroles-operator"
       mutate:
         patchStrategicMerge:
           status:
@@ -82,17 +107,25 @@ spec:
               kinds: [pgroles.io/v1alpha1/PostgresPolicyPlan/status]
               operations: [UPDATE]
       preconditions:
-        any:
+        all:
+          # Only a *newly true* decision counts. The operator's own writes —
+          # creating a plan with Approved=False, recording a rejection it
+          # observed, auto-approving under `approval: auto` — must not be
+          # treated as a reviewer decision, or the operator would need the
+          # approve verb and would have its own decidedBy overwritten.
           - key: >-
-              {{ to_string(request.object.status.conditions[?type == 'Approved'] || `[]`) }}
-            operator: NotEquals
+              {{ length(request.object.status.conditions[?(type == 'Approved' || type == 'Denied') && status == 'True']) }}
+            operator: GreaterThan
             value: >-
-              {{ to_string(request.oldObject.status.conditions[?type == 'Approved'] || `[]`) }}
-          - key: >-
-              {{ to_string(request.object.status.conditions[?type == 'Denied'] || `[]`) }}
+              {{ length(request.oldObject.status.conditions[?(type == 'Approved' || type == 'Denied') && status == 'True'] || `[]`) }}
+          # EDIT THIS if you install the operator under a different namespace
+          # or ServiceAccount name (Helm: `operator.serviceAccount.name`,
+          # `--namespace`). Kyverno cannot resolve it for you, and getting it
+          # wrong means the operator's own status writes are treated as
+          # reviewer decisions and rejected.
+          - key: "{{ request.userInfo.username }}"
             operator: NotEquals
-            value: >-
-              {{ to_string(request.oldObject.status.conditions[?type == 'Denied'] || `[]`) }}
+            value: "system:serviceaccount:pgroles-system:pgroles-operator"
       context:
         - name: subjectaccessreview
           apiCall:

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -325,19 +325,41 @@ wait_for_plan_phase() {
 # exactly the trust boundary documented in operator-plan-approval.md.
 decide_plan() {
   local plan="$1" condition="$2" reason="$3"
-  local now
+  local now existing merged
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  # Append rather than merge: a merge patch replaces `status.conditions`
-  # wholesale and would delete the operator's Computed condition.
-  kubectl patch pgplan "$plan" --subresource=status --type=json -p "$(cat <<JSON
-[
-  {"op": "add", "path": "/status/conditions/-",
-   "value": {"type": "$condition", "status": "True", "reason": "$reason",
-             "message": "recorded by e2e", "lastTransitionTime": "$now"}},
-  {"op": "add", "path": "/status/decidedBy", "value": {"username": "e2e-reviewer"}}
+
+  # Replace any existing decision condition rather than appending one.
+  #
+  # A plan is created carrying `Approved=False`, so a blind append leaves two
+  # `Approved` entries; the operator's own condition writer then flips the
+  # first, producing two `Approved=True`. The CRD's terminality rule compares
+  # the decision types that are true, so that reads as ['Approved','Approved']
+  # against ['Approved'] and the operator's write is rejected — the plan can
+  # never reach Applied. A plain merge patch avoids the duplicate but deletes
+  # the operator's Computed condition, so read, filter, and write back.
+  if ! existing="$(kubectl get pgplan "$plan" -o json)"; then
+    echo "::error::could not read PostgresPolicyPlan $plan" >&2
+    return 1
+  fi
+
+  merged="$(printf '%s' "$existing" | python3 -c "
+import json, sys
+status = json.load(sys.stdin).get('status', {})
+conditions = [
+    c for c in status.get('conditions', [])
+    if c.get('type') not in ('Approved', 'Denied')
 ]
-JSON
-)"
+conditions.append({
+    'type': '$condition', 'status': 'True', 'reason': '$reason',
+    'message': 'recorded by e2e', 'lastTransitionTime': '$now',
+})
+print(json.dumps({'status': {
+    'conditions': conditions,
+    'decidedBy': {'username': 'e2e-reviewer'},
+}}))
+")" || return 1
+
+  kubectl patch pgplan "$plan" --subresource=status --type=merge -p "$merged"
 }
 
 approve_plan() {

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -327,21 +327,15 @@ decide_plan() {
   local plan="$1" condition="$2" reason="$3"
   local now
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  kubectl patch pgplan "$plan" --subresource=status --type=merge -p "$(cat <<JSON
-{
-  "status": {
-    "conditions": [
-      {
-        "type": "$condition",
-        "status": "True",
-        "reason": "$reason",
-        "message": "recorded by e2e",
-        "lastTransitionTime": "$now"
-      }
-    ],
-    "decidedBy": { "username": "e2e-reviewer" }
-  }
-}
+  # Append rather than merge: a merge patch replaces `status.conditions`
+  # wholesale and would delete the operator's Computed condition.
+  kubectl patch pgplan "$plan" --subresource=status --type=json -p "$(cat <<JSON
+[
+  {"op": "add", "path": "/status/conditions/-",
+   "value": {"type": "$condition", "status": "True", "reason": "$reason",
+             "message": "recorded by e2e", "lastTransitionTime": "$now"}},
+  {"op": "add", "path": "/status/decidedBy", "value": {"username": "e2e-reviewer"}}
+]
 JSON
 )"
 }

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -316,14 +316,42 @@ wait_for_plan_phase() {
   return 1
 }
 
+# Record a terminal decision on a plan's status subresource.
+#
+# The decision and the deciding identity must land in one write: CEL rejects a
+# decision condition without `decidedBy`. In a cluster running the Kyverno
+# reference policy the `decidedBy` sent here is overwritten with the caller's
+# authenticated identity; without that policy it stands as written, which is
+# exactly the trust boundary documented in operator-plan-approval.md.
+decide_plan() {
+  local plan="$1" condition="$2" reason="$3"
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  kubectl patch pgplan "$plan" --subresource=status --type=merge -p "$(cat <<JSON
+{
+  "status": {
+    "conditions": [
+      {
+        "type": "$condition",
+        "status": "True",
+        "reason": "$reason",
+        "message": "recorded by e2e",
+        "lastTransitionTime": "$now"
+      }
+    ],
+    "decidedBy": { "username": "e2e-reviewer" }
+  }
+}
+JSON
+)"
+}
+
 approve_plan() {
-  local plan="$1"
-  kubectl annotate pgplan "$plan" pgroles.io/approved=true --overwrite
+  decide_plan "$1" Approved ApprovedByReviewer
 }
 
 reject_plan() {
-  local plan="$1"
-  kubectl annotate pgplan "$plan" pgroles.io/rejected=true --overwrite
+  decide_plan "$1" Denied DeniedByReviewer
 }
 
 get_plan_sql() {


### PR DESCRIPTION
Phase 0 item 3 of #173. Targets `main` directly.

## The problem

Approval was a mutable annotation. Anyone who could patch a `PostgresPolicyPlan` could set `pgroles.io/approved`, unset it, flip to rejected and back — and nothing recorded who decided, or that anything had changed. `approval: manual` was a convention, not a boundary.

## What changed

Decisions move to the status subresource as terminal `Approved` / `Denied` conditions, under the same CEL grammar `EphemeralAccessRequest` already ships:

| Rule | Effect |
| --- | --- |
| mutual exclusion | `Approved=True` and `Denied=True` cannot coexist |
| terminality | the set of true decision conditions never changes once non-empty |
| identity write-once | `decidedBy` cannot be altered after it is set |
| pairing | a terminal decision and `decidedBy` must be written together |

The annotations are **removed outright** rather than deprecated. Pre-1.0, and a retired approval path that still worked would be a silent bypass of everything above — `the_retired_approval_annotation_grants_nothing` pins that an annotated plan now carries no authority at all.

The actor type is shared as `DecisionActor` so both lifecycles record who decided in one vocabulary, per the #173 target API surface.

Under `approval: auto` the operator stamps *itself* as the decider. The pairing rule would reject an unattributed decision anyway, and the audit trail should say plainly that no human reviewed it.

## The part that is not enforceable in CEL

Kubernetes CEL cannot see `request.userInfo`. The API server can force `decidedBy` to be present and immutable, but it cannot check that it names the account that actually wrote it — in the quick start, you type your own username into the field.

`k8s/security/plan-decision-kyverno.yaml` is what closes that gap:

- it overwrites `decidedBy` from the authenticated admission request, and
- it requires the logical `approve` verb on the parent `PostgresPolicy`, so patch access to `postgrespolicyplans/status` — which the operator also holds — is not by itself authority to approve a database change.

Without it installed, `decidedBy` is an assertion. That is stated as a deployment requirement in the docs, in a callout where a reviewer will actually read it, rather than leaving the field looking stronger than it is.

## Verification

- **Unit** — decision read from conditions; `Approved=False` (how every plan is born) is the absence of a decision, not a denial; a contradictory `Approved=True`+`Denied=True` fails closed to rejected; a statusless plan reads Pending rather than panicking; retired annotations grant nothing.
- **E2E** — `approve_plan` / `reject_plan` in `scripts/e2e-helpers.sh` now write status decisions, so the existing plan-lifecycle E2E exercises the real mechanism against a live API server, including the CEL rules.
- **CRDs** regenerated; drift and helm-docs gates clean.

## Docs

The approval page claimed the annotations were already removed and that a status patch worked — both false until this commit, and the largest item in #184. Its design-preview callout was also inverted, marking shipped guarantees as unbuilt while unbuilt CLI commands read as available; it now names both directions accurately. Rejection is documented for the first time.

## Not in this PR

The remaining #184 items (unbuilt `pgroles plan ...` commands, `mode: observe`, the pre-approval Secret claim) and all of #185. Phase 0 items 4–5 remain #180 and #181.

Closes #179. Refs #173, #184.

https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGdj9MJHTYinybQDE6Zmop)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plan approvals and denials are now recorded as terminal status decisions with reviewer identity.
  - Added authorization controls to ensure only permitted operators can approve or deny plans.
  - Decision records are protected from conflicting or subsequent changes.

- **Documentation**
  - Updated approval guidance and quick-start instructions for status-based decisions.
  - Clarified that legacy approval annotations no longer affect plan behavior.
  - Documented current and planned operator capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->