### PR TITLE
test(ci): catch an unbounded or crashing operator before production does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,11 @@ jobs:
           assert_password_set empty-pw-user
           wait_for_event_reason empty-password-secret-policy Recovered
 
+          # The broadest set of scenarios in the repository, and until now none
+          # of them could tell a healthy operator from one that was killed and
+          # restarted part way through reaching the same end state.
+          assert_operator_healthy
+
       - name: Verify OTLP metrics reach the collector
         run: |
           for i in $(seq 1 30); do
@@ -855,8 +860,24 @@ jobs:
           pg_query "SELECT has_table_privilege('loadb_10-viewer', 'loadb_10.items', 'SELECT')" loadtest | grep -qx "t"
           pg_query "SELECT has_sequence_privilege('loadb_05-editor', 'loadb_05.audit_seq', 'USAGE')" loadtest | grep -qx "t"
 
+          # Every assertion above is about convergence, which says nothing
+          # about what the operator paid to get there. An operator that was
+          # OOM-killed part way through and came back still converges these
+          # policies eventually, so only a restart check sees it.
+          assert_operator_healthy
+
       - name: Run ephemeral request cache regression
         run: scripts/e2e-ephemeral-request-load.sh
+
+      # Again, because the step above is where 250 requests are pushed through
+      # the operator and is the likelier place for it to die. Its own peak and
+      # throughput budgets are satisfiable by an operator that was killed and
+      # recovered quickly, and the check after the load policies covers only
+      # what ran before it. Two calls also say which scenario did it.
+      - name: Assert the operator survived the whole job
+        run: |
+          source scripts/e2e-helpers.sh
+          assert_operator_healthy
 
       - name: Diagnostics
         if: failure()
@@ -2088,6 +2109,11 @@ jobs:
       - name: Run plan decision admission E2E
         if: matrix.secure == 'true'
         run: scripts/e2e-plan-decision-admission.sh
+
+      - name: Assert the operator survived the ephemeral access scenarios
+        run: |
+          source scripts/e2e-helpers.sh
+          assert_operator_healthy
 
       - name: Diagnostics
         if: failure()

--- a/.github/workflows/operator-fairness-load.yml
+++ b/.github/workflows/operator-fairness-load.yml
@@ -249,6 +249,136 @@ jobs:
           kubectl exec postgres-0 -- psql -U postgres -d loadtest -tAc "SELECT has_sequence_privilege('loada_05-editor', 'loada_05.audit_seq', 'USAGE');" | grep -qx "t"
           kubectl exec postgres-0 -- psql -U postgres -d churntest -tAc "SELECT has_table_privilege('churna_10-viewer', 'churna_10.items', 'SELECT');" | grep -qx "t"
 
+      # The fairness scenarios are the heaviest shape this repository runs:
+      # five policies across three databases, applied at once and then churned
+      # through credential failures. A change that makes concurrent reconciles
+      # cost more memory shows up here and nowhere else, and only as a restart
+      # — every assertion above is about convergence, which an operator that
+      # was OOM-killed and came back can still eventually satisfy.
+      - name: Assert the operator survived the run
+        run: |
+          source scripts/e2e-helpers.sh
+          assert_operator_healthy
+
       - name: Cleanup
         if: always()
         run: kind delete cluster --name pgroles-fairness
+
+  # ---------------------------------------------------------------------------
+  # ACL inspection burst — does peak memory track the concurrency bound or the
+  # policy count?
+  # ---------------------------------------------------------------------------
+  #
+  # The fairness scenarios above cover contention. This one covers allocation,
+  # which is the failure mode this guards against: reconciling a policy
+  # materialises its database's whole managed ACL surface, and with
+  # unbounded concurrency every policy due at once allocates its own copy. On
+  # startup that is all of them.
+  #
+  # Its own cluster, because the fixture is large and its two operator restarts
+  # would perturb the fairness timings next door.
+  acl-inspection-burst:
+    name: ACL Inspection Burst
+    needs: decide
+    if: needs.decide.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-e2e
+        with:
+          cluster-name: pgroles-acl-burst
+
+      - name: Give the operator room to show the difference
+        run: |
+          # The chart ships a 128Mi limit, which this fixture exceeds under
+          # either configuration — that is itself worth knowing, and is the
+          # subject of a separate conversation about the shipped defaults. The
+          # question here is the *shape* of the growth, so the limit is raised
+          # far enough that the bounded run has clear headroom and the
+          # unbounded run is free to be much larger before the kernel steps in.
+          kubectl -n pgroles-system set resources deployment/pgroles-operator \
+            --containers=operator --limits=memory=512Mi --requests=memory=64Mi
+          kubectl -n pgroles-system rollout status deployment/pgroles-operator --timeout=180s
+
+          # Free up `basic-policy` (created by the composite for its health
+          # check) so it is not one more thing reconciling during the burst.
+          kubectl delete pgr basic-policy --wait=true
+
+      - name: Run the ACL inspection burst
+        run: scripts/e2e-acl-inspection-burst.sh
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          kubectl get pgr -A -o wide || true
+          kubectl -n pgroles-system get pods -o wide || true
+          kubectl -n pgroles-system logs deployment/pgroles-operator --tail=500 || true
+          kubectl -n pgroles-system logs deployment/pgroles-operator --previous --tail=500 || true
+          kubectl get events -A --sort-by=.lastTimestamp | tail -100 || true
+
+      - name: Cleanup
+        if: always()
+        run: kind delete cluster --name pgroles-acl-burst
+
+  # ---------------------------------------------------------------------------
+  # Notify on failure
+  # ---------------------------------------------------------------------------
+  #
+  # A nightly nobody reads is a nightly nobody runs. Failures land as an issue
+  # so they surface where the rest of the work does, and repeat failures append
+  # to the open one rather than filing a new issue every morning.
+  notify-failure:
+    name: Create issue on failure
+    needs:
+      - decide
+      - fairness-load
+      - acl-inspection-burst
+    # Branch dispatches are useful for validating changes to this workflow, but
+    # must not create repository issues. Only failures of the workflow on main
+    # represent the maintained nightly signal.
+    if: failure() && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build issue body
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # The heredoc body is indented to match the surrounding YAML block, so
+          # it is unindented on the way out — ten leading spaces would render
+          # the whole issue as one code block.
+          sed 's/^          //' > issue_body.md <<EOF
+          Nightly operator fairness/load run failed on $(date -u +%Y-%m-%d), at commit \`${{ github.sha }}\`.
+
+          **Job results:**
+          - fairness-load: ${{ needs.fairness-load.result }}
+          - acl-inspection-burst: ${{ needs.acl-inspection-burst.result }}
+
+          A failing \`acl-inspection-burst\` means peak reconcile memory is tracking policy
+          count rather than the concurrency bound, or the operator was killed reconciling
+          its own policies. A failing \`fairness-load\` means policies are starving each
+          other, most often behind a shared credential failure.
+
+          [View run](${RUN_URL})
+          EOF
+      - name: Create or update the issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The label has to exist before it can be filtered on or applied.
+          gh label create nightly-failure \
+            --description "A scheduled run failed" --color B60205 2>/dev/null || true
+          EXISTING="$(gh issue list --label nightly-failure --state open --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file issue_body.md
+          else
+            gh issue create \
+              --title "Nightly operator fairness/load failure ($(date -u +%Y-%m-%d))" \
+              --body-file issue_body.md \
+              --label nightly-failure
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ diff(current, effective desired) → Vec<Change> → sql::render_all_with_contex
 - **Plan lifecycle and load E2E** — plan approval flows, plus generated-policy convergence at higher object counts and ephemeral-request load
 - **Ephemeral access E2E** — runs twice: once for the trusted-writer posture, once for the Kyverno secure-admission profile in `k8s/security/`
 
-The heavier fairness/load coverage lives in `.github/workflows/operator-fairness-load.yml` and runs on a nightly schedule when `main` has changed.
+The heavier fairness/load coverage lives in `.github/workflows/operator-fairness-load.yml` and runs on a nightly schedule when `main` has changed. It carries two scenarios — fairness/load, and an ACL inspection burst that measures whether the operator's peak working set tracks the concurrency bound or the policy count — and files a `nightly-failure` issue when either fails, appending to the open one rather than opening a new issue per night.
 
 ## Agent Skills
 

--- a/crates/pgroles-operator/src/main.rs
+++ b/crates/pgroles-operator/src/main.rs
@@ -10,7 +10,7 @@ use futures::{StreamExt, TryStreamExt, stream};
 use k8s_openapi::api::core::v1::Secret;
 use kube::runtime::controller::Config as ControllerConfig;
 use kube::runtime::events::{Recorder, Reporter};
-use kube::runtime::reflector::ObjectRef;
+use kube::runtime::reflector::{ObjectRef, Store};
 use kube::runtime::{Controller, WatchStreamExt, predicates, reflector, watcher};
 use kube::{Api, Client, Resource, ResourceExt};
 use tracing::{info, warn};
@@ -32,6 +32,23 @@ use pgroles_operator::observability::{
 use pgroles_operator::plan::PlanRetention;
 use pgroles_operator::reconciler::{error_policy, reconcile};
 use pgroles_operator::request_index::RequestIndex;
+
+/// Build a controller with the operator-wide concurrency bound already applied.
+///
+/// Keeping construction behind this helper makes the safe path the natural path:
+/// callers cannot receive a controller that still has kube-rs's unbounded default.
+fn configured_controller<K>(
+    trigger: impl futures::Stream<Item = Result<K, watcher::Error>> + Send + 'static,
+    reader: Store<K>,
+    concurrency: ReconcileConcurrency,
+) -> Controller<K>
+where
+    K: Clone + Resource + serde::de::DeserializeOwned + std::fmt::Debug + Send + Sync + 'static,
+    K::DynamicType: Default + Eq + Hash + Clone,
+{
+    Controller::for_stream(trigger, reader)
+        .with_config(ControllerConfig::default().concurrency(concurrency.get()))
+}
 
 /// Hash for plan decision changes — triggers parent policy reconciliation when
 /// a reviewer records a decision, or the operator moves the plan's phase.
@@ -157,8 +174,6 @@ async fn main() -> anyhow::Result<()> {
             "reconcile concurrency bounded"
         );
     }
-    let controller_config = ControllerConfig::default().concurrency(reconcile_concurrency.get());
-
     let plan_retention = PlanRetention::from_env()?;
     if plan_retention != PlanRetention::default() {
         info!(
@@ -317,8 +332,7 @@ async fn main() -> anyhow::Result<()> {
     info!("starting controllers");
     observability.mark_ready();
 
-    let policy_controller = Controller::for_stream(policy_stream, reader)
-        .with_config(controller_config.clone())
+    let policy_controller = configured_controller(policy_stream, reader, reconcile_concurrency)
         .reconcile_on(secret_triggers)
         .reconcile_on(plan_triggers)
         .reconcile_on(candidate_triggers)
@@ -368,21 +382,23 @@ async fn main() -> anyhow::Result<()> {
             stream::iter(refs)
         });
 
-    let access_policy_controller =
-        Controller::for_stream(access_policy_stream, access_policy_reader)
-            .with_config(controller_config.clone())
-            .reconcile_on(target_access_policy_triggers)
-            .shutdown_on_signal()
-            .run(
-                reconcile_access_policy,
-                access_policy_error_policy,
-                ctx.clone(),
-            )
-            .for_each(|result| async move {
-                if let Err(error) = result {
-                    tracing::error!(%error, "ephemeral access policy reconcile failed");
-                }
-            });
+    let access_policy_controller = configured_controller(
+        access_policy_stream,
+        access_policy_reader,
+        reconcile_concurrency,
+    )
+    .reconcile_on(target_access_policy_triggers)
+    .shutdown_on_signal()
+    .run(
+        reconcile_access_policy,
+        access_policy_error_policy,
+        ctx.clone(),
+    )
+    .for_each(|result| async move {
+        if let Err(error) = result {
+            tracing::error!(%error, "ephemeral access policy reconcile failed");
+        }
+    });
 
     let access_requests: Api<EphemeralAccessRequest> = match &watch_namespace {
         Some(namespace) => Api::namespaced(client.clone(), namespace),
@@ -436,17 +452,19 @@ async fn main() -> anyhow::Result<()> {
                 .flat_map(stream::iter)
             });
 
-    let access_request_controller =
-        Controller::for_stream(access_request_stream, access_request_reader)
-            .with_config(controller_config)
-            .reconcile_on(access_policy_request_triggers)
-            .shutdown_on_signal()
-            .run(reconcile_access_request, access_request_error_policy, ctx)
-            .for_each(|result| async move {
-                if let Err(error) = result {
-                    tracing::error!(%error, "ephemeral access request reconcile failed");
-                }
-            });
+    let access_request_controller = configured_controller(
+        access_request_stream,
+        access_request_reader,
+        reconcile_concurrency,
+    )
+    .reconcile_on(access_policy_request_triggers)
+    .shutdown_on_signal()
+    .run(reconcile_access_request, access_request_error_policy, ctx)
+    .for_each(|result| async move {
+        if let Err(error) = result {
+            tracing::error!(%error, "ephemeral access request reconcile failed");
+        }
+    });
 
     futures::future::join3(
         policy_controller,
@@ -471,6 +489,37 @@ mod tests {
         REQUESTED_RECONCILE_ANNOTATION, SecretReference,
     };
     use std::collections::BTreeMap;
+
+    /// Raw controller construction belongs in `configured_controller`, where
+    /// applying the operator-wide concurrency config is part of construction.
+    /// This catches a future controller built directly with kube-rs's unbounded
+    /// default instead of relying on counts that unrelated builder calls can
+    /// accidentally balance.
+    #[test]
+    fn controllers_are_constructed_through_the_configured_helper() {
+        let source = include_str!("main.rs");
+        let body: String = source
+            .split_once("mod tests {")
+            .map(|(before, _)| before)
+            .expect("this binary has a test module")
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(
+            body.matches("Controller::").count(),
+            1,
+            "construct controllers through configured_controller; raw kube-rs controllers use \
+             unbounded concurrency by default"
+        );
+        assert!(
+            body.contains(
+                ".with_config(ControllerConfig::default().concurrency(concurrency.get()))"
+            ),
+            "configured_controller must apply the resolved concurrency bound"
+        );
+    }
 
     fn test_policy() -> PostgresPolicy {
         let spec = PostgresPolicySpec {

--- a/scripts/e2e-acl-inspection-burst.sh
+++ b/scripts/e2e-acl-inspection-burst.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Does peak reconcile memory track the concurrency bound, or the policy count?
+#
+# Reconciling a PostgresPolicy materialises the whole managed ACL surface of
+# its database, and the function read is one `aclexplode` row per function per
+# grantee. With unbounded concurrency every policy whose watch fires allocates
+# its own copy of that at the same moment, so peak scales with how many
+# policies happen to be due — which on operator startup is all of them. Nothing
+# else in this repository could see that failure mode: every other scenario asserts
+# convergence, which an operator that was killed and came back still reaches.
+#
+# The measurement here is a restart, because a restart is the burst: every
+# watch fires together. It runs twice against the same fixture, unbounded
+# first so each phase starts from a fresh pod with a clean baseline, and
+# asserts the relationship rather than an absolute — a threshold nobody has
+# measured is a coin flip, while "bounded must cost materially less than
+# unbounded" is exactly the property the bound claims, and it fails the moment
+# the bound stops being applied.
+#
+# Sizing is env-overridable so the shape can be turned up as runners allow.
+# Rows per policy are schemas x functions x roles: the defaults give 40,000,
+# which is large enough to exercise the inspection path meaningfully.
+policy_count="${BURST_POLICIES:-10}"
+schema_count="${BURST_SCHEMAS:-10}"
+function_count="${BURST_FUNCTIONS:-100}"
+role_count="${BURST_ROLES:-40}"
+# The bounded run must stay under this share of the unbounded run's peak.
+# Generous on purpose: the defaults give unbounded 2.5x the concurrency of
+# bounded, so a real bound clears this comfortably and only its removal, which
+# makes the two runs identical, cannot.
+max_bounded_share_percent="${BURST_MAX_BOUNDED_SHARE_PERCENT:-80}"
+
+namespace=pgroles-system
+deployment="deployment/pgroles-operator"
+sample_file="$(mktemp)"
+stop_file="$(mktemp)"
+rm -f "$stop_file"
+sampler_pid=""
+
+cleanup() {
+  touch "$stop_file"
+  if [ -n "$sampler_pid" ]; then
+    wait "$sampler_pid" 2>/dev/null || true
+  fi
+  rm -f "$sample_file" "$stop_file"
+}
+trap cleanup EXIT
+
+source "$(dirname "$0")/e2e-helpers.sh"
+
+policy_name() { printf 'burst-%02d' "$1"; }
+database_name() { printf 'burst%02d' "$1"; }
+secret_name() { printf 'burst-%02d-credentials' "$1"; }
+# Roles are cluster-wide even though databases are not, so every policy needs
+# its own role names. Sharing them would put ten policies in charge of one set
+# of roles, which the operator correctly reports as a conflict.
+role_prefix_for() { printf 'burst%02d_reader' "$1"; }
+
+# The kubelet's stats endpoint is briefly unavailable for a pod that has just
+# started, and a single failed read under `set -e` would end the run rather
+# than the sample.
+operator_memory_bytes_settled() {
+  local attempt value
+  for attempt in $(seq 1 30); do
+    value="$(operator_memory_bytes 2>/dev/null || true)"
+    if [ -n "$value" ]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "::error::the kubelet reported no memory for the operator container" >&2
+  return 1
+}
+
+# Every burst policy has reconciled at least once since `since`, an RFC3339
+# UTC timestamp. These sort lexicographically, which is the whole reason the
+# comparison can be done in the shell.
+wait_for_reconciles_since() {
+  local since="$1" attempts="${2:-120}"
+  local attempt done_count i name stamp
+  for attempt in $(seq 1 "$attempts"); do
+    done_count=0
+    for i in $(seq 1 "$policy_count"); do
+      name="$(policy_name "$i")"
+      stamp="$(kubectl get pgr "$name" \
+        -o jsonpath='{.status.last_successful_reconcile_time}' 2>/dev/null || true)"
+      if [ -n "$stamp" ] && [ "$stamp" \> "$since" ]; then
+        done_count=$(( done_count + 1 ))
+      fi
+    done
+    if [ "$done_count" -eq "$policy_count" ]; then
+      echo "all $policy_count policies reconciled since $since"
+      return 0
+    fi
+    echo "Waiting for reconciles since $since ($done_count/$policy_count, attempt $attempt/$attempts)"
+    sleep 5
+  done
+  echo "::error::only $done_count/$policy_count policies reconciled since $since"
+  kubectl get pgr -o wide || true
+  kubectl -n "$namespace" logs "$deployment" --tail=200 || true
+  return 1
+}
+
+# Sample the operator across the restart the caller just triggered, and set
+# `measured_peak` to the highest working-set sample from the fresh pod.
+#
+# The result is a global rather than stdout because everything in here — the
+# rollout, the reconcile wait — is output a caller would want to see, and
+# capturing the function's stdout would swallow it.
+measured_peak=0
+stop_sampler() {
+  if [ -n "$sampler_pid" ]; then
+    touch "$stop_file"
+    wait "$sampler_pid" 2>/dev/null || true
+    sampler_pid=""
+  fi
+}
+
+measure_rollout_burst() {
+  local label="$1" since="$2"
+  local baseline peak
+
+  kubectl -n "$namespace" rollout status "$deployment" --timeout=180s || return 1
+
+  # A fresh pod, so the baseline is not carrying the previous phase's
+  # allocations: glibc does not necessarily return freed pages to the OS, and a
+  # baseline that already included the last burst would flatten the difference
+  # being measured. It is taken as soon as the pod is Ready, which is a moment
+  # after its first reconciles begin, so it errs high and the reported growth
+  # errs low.
+  baseline="$(operator_memory_bytes_settled)" || return 1
+
+  # A phase that failed part way may have left its sampler running; it would
+  # otherwise keep appending to the file this phase is about to read.
+  stop_sampler
+
+  rm -f "$sample_file" "$stop_file"
+  touch "$sample_file"
+  printf '%s\n' "$baseline" >>"$sample_file"
+  (
+    while [ ! -e "$stop_file" ]; do
+      operator_memory_bytes >>"$sample_file" 2>/dev/null || true
+      sleep 1
+    done
+  ) &
+  sampler_pid="$!"
+
+  if ! wait_for_reconciles_since "$since"; then
+    stop_sampler
+    return 1
+  fi
+
+  stop_sampler
+  operator_memory_bytes >>"$sample_file" 2>/dev/null || true
+
+  peak="$(sort -nr "$sample_file" | head -n 1)"
+  if [ -z "$peak" ]; then
+    echo "::error::no memory samples were collected for the $label phase" >&2
+    return 1
+  fi
+  measured_peak="$peak"
+  printf '%s: first-sample=%s peak=%s bytes\n' \
+    "$label" "$baseline" "$measured_peak"
+}
+
+# -- Fixture ------------------------------------------------------------------
+
+echo "Seeding $policy_count databases with ${schema_count}x${function_count} functions granted to $role_count roles"
+
+for i in $(seq 1 "$policy_count"); do
+  database="$(database_name "$i")"
+  if ! kubectl exec -i postgres-0 -- psql -tA -U postgres -d postgres \
+    -c "SELECT 1 FROM pg_database WHERE datname = '${database}'" | grep -qx 1; then
+    kubectl exec -i postgres-0 -- psql -v ON_ERROR_STOP=1 -U postgres -d postgres \
+      -c "CREATE DATABASE \"${database}\""
+  fi
+  kubectl create secret generic "$(secret_name "$i")" \
+    --from-literal=DATABASE_URL="postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/${database}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+done
+
+for i in $(seq 1 "$policy_count"); do
+  database="$(database_name "$i")"
+  bash "$(dirname "$0")/generate-acl-burst-sql.sh" \
+    "burst" "$schema_count" "$function_count" "$(role_prefix_for "$i")" "$role_count" \
+    | kubectl exec -i postgres-0 -- psql -q -v ON_ERROR_STOP=1 -U postgres -d "$database"
+  echo "seeded $database"
+done
+
+for i in $(seq 1 "$policy_count"); do
+  bash "$(dirname "$0")/generate-acl-burst-policy.sh" \
+    "$(policy_name "$i")" "$(secret_name "$i")" \
+    "burst" "$schema_count" "$(role_prefix_for "$i")" "$role_count" \
+    "/tmp/$(policy_name "$i").yaml"
+  kubectl apply -f "/tmp/$(policy_name "$i").yaml"
+done
+
+# The fixture is pre-granted, so this first pass should find every database
+# already converged. Waiting it out separates the apply from the measurement:
+# what follows measures inspection, not the cost of a first apply.
+for i in $(seq 1 "$policy_count"); do
+  wait_for_ready_true "$(policy_name "$i")" 90 5
+done
+
+# -- Measurement --------------------------------------------------------------
+
+# Each phase settles its configuration change first and then restarts
+# explicitly, rather than relying on the env change to roll the deployment.
+# Removing a variable that is already absent is a no-op, and a phase that
+# quietly failed to restart would measure an idle operator and pass.
+#
+# `since` is taken before the restart: a timestamp taken after the new pod is
+# Ready would miss the reconciles it had already started, and the wait would
+# then sit out a whole 5m interval waiting for the next ones.
+run_phase() {
+  local label="$1"
+  shift
+  kubectl -n "$namespace" set env "$deployment" "$@" || return 1
+  kubectl -n "$namespace" rollout status "$deployment" --timeout=180s || return 1
+
+  local since
+  since="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  kubectl -n "$namespace" rollout restart "$deployment" || return 1
+  measure_rollout_burst "$label" "$since" || return 1
+}
+
+# The unbounded phase is allowed to fail. Being OOM-killed, or never getting
+# every policy through a reconcile because it keeps being killed, is a result
+# rather than an error — it says the bound matters more loudly than any ratio
+# would. What it costs is the comparison, so the ratio assertion below is
+# skipped when this phase does not complete, and the bounded phase carries the
+# run on its own.
+unbounded_completed=1
+run_phase 'unbounded (RECONCILE_CONCURRENCY=0)' RECONCILE_CONCURRENCY=0 || unbounded_completed=0
+unbounded_peak="$measured_peak"
+kubectl -n "$namespace" get pods -o wide || true
+if [ "$unbounded_completed" -eq 0 ]; then
+  echo "the unbounded phase did not complete; the bounded phase is the whole assertion"
+fi
+
+run_phase 'bounded (default)' RECONCILE_CONCURRENCY-
+bounded_peak="$measured_peak"
+
+printf 'ACL inspection burst: %s policies x %s schemas x %s functions x %s roles (%s ACL rows each). Peak working set after restart: unbounded %s MiB, bounded %s MiB.\n' \
+  "$policy_count" "$schema_count" "$function_count" "$role_count" \
+  "$(( schema_count * function_count * role_count ))" \
+  "$(( unbounded_peak / 1048576 ))" "$(( bounded_peak / 1048576 ))" \
+  | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# -- Assertions ---------------------------------------------------------------
+
+# The bounded run is the one that has to survive. An operator killed while
+# reconciling its own policies fails the property this scenario protects.
+assert_operator_healthy "$namespace"
+
+if [ "$unbounded_completed" -eq 0 ]; then
+  printf 'Unbounded phase did not complete, so only the bounded phase was asserted. Bounded peak %s bytes.\n' \
+    "$bounded_peak"
+  exit 0
+fi
+
+if [ "$unbounded_peak" -le 0 ]; then
+  echo "::error::the unbounded run produced no working-set samples, so the comparison measured nothing"
+  exit 1
+fi
+
+allowed=$(( unbounded_peak * max_bounded_share_percent / 100 ))
+if [ "$bounded_peak" -gt "$allowed" ]; then
+  echo "::error::bounded reconciles reached a ${bounded_peak}-byte working set against ${unbounded_peak} unbounded (allowed ${allowed}, ${max_bounded_share_percent}%). Peak memory is tracking policy count rather than the concurrency bound."
+  exit 1
+fi
+
+printf 'Bounded peak %s bytes is within %s%% of unbounded %s bytes\n' \
+  "$bounded_peak" "$max_bounded_share_percent" "$unbounded_peak"

--- a/scripts/e2e-ephemeral-request-load.sh
+++ b/scripts/e2e-ephemeral-request-load.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "$0")/e2e-helpers.sh"
+
 # A deliberately modest request-cache regression for a standard GitHub-hosted
 # runner. This does not claim a production capacity limit; ResourceQuota should
 # provide that hard stop. It catches accidental per-request memory explosions
@@ -28,23 +30,6 @@ cleanup() {
   rm -f "$sample_file" "$stop_file"
 }
 trap cleanup EXIT
-
-operator_memory_bytes() {
-  local pod_json pod_uid node
-  pod_json="$(kubectl -n pgroles-system get pod \
-    -l app.kubernetes.io/name=pgroles-operator -o json)"
-  pod_uid="$(jq -r '.items[0].metadata.uid' <<<"$pod_json")"
-  node="$(jq -r '.items[0].spec.nodeName' <<<"$pod_json")"
-  kubectl get --raw "/api/v1/nodes/${node}/proxy/stats/summary" \
-    | jq -er --arg uid "$pod_uid" '
-        .pods[]
-        | select(.podRef.uid == $uid)
-        | .containers[]
-        | select(.name == "operator")
-        | (.memory.workingSetBytes // .memory.usageBytes)
-        | select(. > 0)
-      '
-}
 
 wait_for_access_policy() {
   for attempt in $(seq 1 45); do

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -628,3 +628,76 @@ wait_for_pending_plan_ref() {
   kubectl get pgplan -l "pgroles.io/policy=$policy" -o wide >&2 || true
   return 1
 }
+
+# -- Operator health helpers --------------------------------------------------
+
+active_operator_pod_json() {
+  local namespace="${1:-pgroles-system}"
+  kubectl -n "$namespace" get pods \
+    -l app.kubernetes.io/name=pgroles-operator -o json \
+    | jq -e '
+        [.items[] | select(.metadata.deletionTimestamp == null)]
+        | if length == 1 then .[0]
+          else error("expected exactly one active operator pod, found \(length)")
+          end
+      '
+}
+
+# Working set of the active operator container, from kubelet accounting.
+operator_memory_bytes() {
+  local namespace="${1:-pgroles-system}"
+  local pod_json pod_uid node
+  pod_json="$(active_operator_pod_json "$namespace")" || return 1
+  pod_uid="$(jq -r '.metadata.uid' <<<"$pod_json")"
+  node="$(jq -r '.spec.nodeName' <<<"$pod_json")"
+  kubectl get --raw "/api/v1/nodes/${node}/proxy/stats/summary" \
+    | jq -er --arg uid "$pod_uid" '
+        .pods[]
+        | select(.podRef.uid == $uid)
+        | .containers[]
+        | select(.name == "operator")
+        | (.memory.workingSetBytes // .memory.usageBytes)
+        | select(. > 0)
+      '
+}
+
+# Fail if the operator crashed during a scenario, naming the reason.
+#
+# Memory is the resource an operator overruns silently: peak allocation scales
+# with how much of a database a reconcile inspects and with how many reconciles
+# run at once, neither of which any assertion about policy convergence can see.
+# A run whose policies all reached Ready can still have had the operator
+# OOM-killed and restarted underneath it, which in a real cluster is
+# CrashLoopBackOff and a policy graph that stops converging. E2E deploys the
+# operator at the same 128Mi limit the chart ships, so a regression that widens
+# peak memory shows up here as a restart, and only if something looks.
+#
+# `OOMKilled` is called out separately from other exit reasons because it is
+# the one that says the change was in memory rather than in logic.
+assert_operator_healthy() {
+  local namespace="${1:-pgroles-system}"
+  local pod_json pod restarts reason
+
+  if ! pod_json="$(active_operator_pod_json "$namespace" 2>/dev/null)"; then
+    echo "::error::expected exactly one active operator pod in $namespace"
+    kubectl -n "$namespace" get pods -o wide || true
+    return 1
+  fi
+  pod="$(jq -r '.metadata.name' <<<"$pod_json")"
+  restarts="$(jq -r '[.status.containerStatuses[]? | select(.name == "operator")][0].restartCount // 0' <<<"$pod_json")"
+  reason="$(jq -r '[.status.containerStatuses[]? | select(.name == "operator")][0].lastState.terminated.reason // empty' <<<"$pod_json")"
+
+  if [ "$reason" = "OOMKilled" ]; then
+    echo "::error::operator pod $pod was OOM-killed ($restarts restart(s)); peak memory now exceeds the deployed limit"
+  elif [ "${restarts:-0}" -gt 0 ]; then
+    echo "::error::operator pod $pod restarted $restarts time(s), last termination reason: ${reason:-unknown}"
+  else
+    echo "operator pod $pod: 0 restarts"
+    return 0
+  fi
+
+  kubectl -n "$namespace" get pods -o wide || true
+  kubectl -n "$namespace" describe deployment/pgroles-operator || true
+  kubectl -n "$namespace" logs deployment/pgroles-operator --previous --tail=200 || true
+  return 1
+}

--- a/scripts/generate-acl-burst-policy.sh
+++ b/scripts/generate-acl-burst-policy.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# A PostgresPolicy declaring exactly what generate-acl-burst-sql.sh seeded, so
+# the first reconcile finds the database already converged and its cost is the
+# inspection rather than the apply.
+#
+# The roles are shared across every schema on purpose. Profiles scope a role to
+# one schema, which keeps the ACL row count linear in schemas; a role granted
+# in every schema makes it the product and exercises the high-cardinality ACL
+# inspection path this fixture is intended to measure.
+set -euo pipefail
+
+policy_name="${1:?policy name}"
+secret_name="${2:?secret name}"
+schema_prefix="${3:?schema prefix}"
+schema_count="${4:?schema count}"
+role_prefix="${5:?role prefix}"
+role_count="${6:?role count}"
+output_path="${7:-/dev/stdout}"
+
+{
+  cat <<YAML
+---
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: ${policy_name}
+  namespace: default
+spec:
+  connection:
+    secretRef:
+      name: ${secret_name}
+  interval: "5m"
+  mode: apply
+  approval: auto
+  default_owner: postgres
+
+  schemas:
+YAML
+
+  for s in $(seq -w 1 "${schema_count}"); do
+    echo "    - name: ${schema_prefix}_${s}"
+  done
+
+  echo "  roles:"
+  for r in $(seq -w 1 "${role_count}"); do
+    cat <<YAML
+    - name: ${role_prefix}_${r}
+      login: false
+YAML
+  done
+
+  echo "  grants:"
+  for r in $(seq -w 1 "${role_count}"); do
+    for s in $(seq -w 1 "${schema_count}"); do
+      cat <<YAML
+    - role: ${role_prefix}_${r}
+      privileges: [USAGE]
+      object: { type: schema, name: ${schema_prefix}_${s} }
+    - role: ${role_prefix}_${r}
+      privileges: [EXECUTE]
+      object: { type: function, schema: ${schema_prefix}_${s}, name: "*" }
+YAML
+    done
+  done
+} > "${output_path}"

--- a/scripts/generate-acl-burst-sql.sh
+++ b/scripts/generate-acl-burst-sql.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Seed one database with the object shape that makes a reconcile expensive to
+# *read*: many functions, in many schemas, each granted to many roles.
+#
+# Inspection cost is one `aclexplode` row per function per grantee, so rows
+# are schemas x functions x roles. The grants are pre-seeded here rather than
+# left for the operator to apply, because this fixture exists to size the
+# inspection, not the apply — a policy that converges on its first pass still
+# reads the whole inventory, which is the allocation being measured.
+#
+# Roles are created here too, so the policy adopts existing roles instead of
+# spending its first reconcile creating them.
+set -euo pipefail
+
+schema_prefix="${1:?schema prefix}"
+schema_count="${2:?schema count}"
+function_count="${3:?functions per schema}"
+role_prefix="${4:?role prefix}"
+role_count="${5:?role count}"
+
+echo "BEGIN;"
+
+for r in $(seq -w 1 "${role_count}"); do
+  role="${role_prefix}_${r}"
+  # DO block rather than CREATE ROLE IF NOT EXISTS, which PostgreSQL has no
+  # spelling for.
+  cat <<SQL
+DO \$\$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
+    CREATE ROLE "${role}" NOLOGIN;
+  END IF;
+END \$\$;
+SQL
+done
+
+for s in $(seq -w 1 "${schema_count}"); do
+  schema="${schema_prefix}_${s}"
+  echo "CREATE SCHEMA IF NOT EXISTS \"${schema}\";"
+  for f in $(seq -w 1 "${function_count}"); do
+    # Trivial bodies: the ACL entry is the payload, not the function.
+    echo "CREATE OR REPLACE FUNCTION \"${schema}\".fn_${f}(input integer) RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT input';"
+  done
+  for r in $(seq -w 1 "${role_count}"); do
+    role="${role_prefix}_${r}"
+    echo "GRANT USAGE ON SCHEMA \"${schema}\" TO \"${role}\";"
+    echo "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA \"${schema}\" TO \"${role}\";"
+  done
+done
+
+echo "COMMIT;"


### PR DESCRIPTION
Follows #209 and is rebased onto its merge commit.

## Why

#209 bounds controller reconciliation concurrency, but the repository previously had no regression guard for either accidentally constructing an unbounded controller or restarting under realistic load.

## What changed

- All controllers are constructed through one helper that applies the resolved concurrency bound. A structural test rejects raw controller construction elsewhere in the binary.
- `assert_operator_healthy` makes the regular operator and load E2E jobs fail if the active operator container restarted, with `OOMKilled` reported explicitly.
- The scheduled fairness/load workflow now includes an ACL inspection burst. It seeds ten databases with high-cardinality function ACLs, compares fresh-pod peak working sets with bounded and unbounded reconciliation, and requires the bounded run to survive.
- Nightly failures on `main` create or update a `nightly-failure` issue. Manual branch dispatches remain safe for validation and do not create repository issues.

## Review hardening

- The load-job health assertion now also runs after the 250-request ephemeral-access workload.
- Memory sampling requires exactly one non-terminating operator pod, so rollout pods cannot be confused.
- The existing ephemeral-request sampler now uses the same checked active-pod implementation, and both full ephemeral-access E2E variants assert that the operator did not restart.
- Failure propagation is explicit in the optional unbounded phase; Bash's conditional `set -e` behavior can no longer turn a failed rollout or reconcile wait into a successful measurement.
- Samplers are stopped on both success and failure.

## Verification

- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER=/usr/bin/env SQLX_OFFLINE=true cargo test -p pgroles-operator --bin pgroles-operator`
- `RUSTC_WRAPPER=/usr/bin/env SQLX_OFFLINE=true cargo clippy -p pgroles-operator --all-targets --all-features -- -D warnings`
- `bash -n` for all touched shell scripts
- Both workflow files parse as YAML

The first manual ACL-burst run exposed and validated a harness correction: its first observable unbounded sample was already the peak, so subtracting it as a baseline falsely reported zero growth even though the bounded and unbounded peaks separated materially. The final gate is a successful rerun using the corrected peak-to-peak assertion.
