### PR TITLE
Fix wildcard revocation, isolate ACL derivation, and repair onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,9 @@ jobs:
         with:
           cluster-name: pgroles-e2e-operator
 
+      - name: Run the documented operator quick start
+        run: scripts/e2e-doc-quick-start.sh
+
       - name: Run operator scenarios
         run: |
           source scripts/e2e-helpers.sh

--- a/.github/workflows/operator-fairness-load.yml
+++ b/.github/workflows/operator-fairness-load.yml
@@ -278,17 +278,26 @@ jobs:
   # Its own cluster, because the fixture is large and its two operator restarts
   # would perturb the fairness timings next door.
   acl-inspection-burst:
-    name: ACL Inspection Burst
+    name: ACL Inspection Burst (${{ matrix.workers }} workers)
     needs: decide
     if: needs.decide.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        workers: [1, 2]
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-e2e
         with:
           cluster-name: pgroles-acl-burst
+
+      - name: Set runtime worker count
+        run: |
+          kubectl -n pgroles-system set env deployment/pgroles-operator TOKIO_WORKER_THREADS=${{ matrix.workers }}
+          kubectl -n pgroles-system rollout status deployment/pgroles-operator --timeout=180s
 
       - name: Give the operator room to show the difference
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wildcard revocations retain concrete object/grantor attribution, including PUBLIC and mixed-owner scopes. Normalization preserves named-object exceptions; owner privileges remain protected. Revocations may produce more concrete plan entries and require fresh approval when effects differ. (#215)
+- Operator onboarding examples now name the target database, and documentation validation checks policy semantics in addition to JSON Schema. The CLI quick start uses additive mode; adoption and upgrade guides explain mode and version transitions.
+
+### Changed
+
+- ACL derivation runs on a single bounded blocking worker per process without copying the raw snapshot. Inspection exposes ACL/grantor cardinality and derivation phases; operator telemetry adds processing duration and runtime scheduling lag. Removed redundant ACL query sorting and an intermediate row-pointer allocation. Reconcile concurrency still defaults to one. (#214)
+
 ## [0.10.1] - 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Declarative PostgreSQL access control. Define roles, schema ownership, grants, a
 
 For simple setups, use a single manifest. For larger teams, the CLI also supports bundle composition: shared profiles plus multiple scoped policy fragments merged into one desired plan with conflict checks before any database diff or apply.
 
-By default, anything not in the manifest gets revoked or dropped. Same model as Terraform, applied to PostgreSQL. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones. In additive mode, pgroles also leaves attributes, comments, and config defaults unchanged on pre-existing roles.
+The default authoritative mode revokes undeclared access and drops eligible roles within the managed inspection scope. PUBLIC privileges require explicit rules; pgroles does not manage every role and object in the database. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones. In additive mode, pgroles also leaves attributes, comments, and config defaults unchanged on pre-existing roles.
 
 ## How it works
 

--- a/correctness/performance/acl-inspection.md
+++ b/correctness/performance/acl-inspection.md
@@ -1,0 +1,76 @@
+# ACL inspection measurements (#214)
+
+Use a disposable PostgreSQL database. The fixture creates 1,000 functions,
+40 grantees, and 40,040 managed ACL rows (including schema USAGE).
+
+```sh
+scripts/generate-acl-burst-sql.sh bench 1 1000 bench 40 | psql "$DATABASE_URL" -v ON_ERROR_STOP=1
+```
+
+Create a manifest declaring the 40 `bench_01` through `bench_40` roles and an
+EXECUTE wildcard on `bench_1` functions for each role. The profile example is
+read-only and reports any extra schema-USAGE revocations without applying them.
+
+```sh
+cargo build --release -p pgroles-inspect --example inspection_profile
+TOKIO_WORKER_THREADS=1 PROFILE_INLINE=1 target/release/examples/inspection_profile policy.yaml
+TOKIO_WORKER_THREADS=1 target/release/examples/inspection_profile policy.yaml
+# Repeat with TOKIO_WORKER_THREADS=2.
+```
+
+The workload runs on a Tokio worker, not the root thread of `tokio::main`.
+A separate 10 ms timer reports its maximum scheduling delay. This is a runtime
+responsiveness experiment, not an HTTP health-probe latency measurement.
+`PROFILE_INLINE=1` uses the synchronous derivation API; the default exercises
+the bounded path used by production inspection and shared candidate planning.
+
+## Query experiment
+
+PostgreSQL 18 in a local Docker container, macOS host, nine runs per variant.
+The SQL files alongside this document preserve both queries. Prefix each with
+`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` to reproduce. For sparse results,
+replace the 40-role array with `ARRAY['bench_01']`.
+
+| Qualifying ACLs | Existing query, median | Filtered materialized signature query, median |
+| --- | ---: | ---: |
+| Dense: 40 roles | 18.708 ms | 25.047 ms |
+| Sparse: 1 role | 6.194 ms | 11.039 ms |
+
+The materialized variant first identifies qualifying functions, computes each
+identity signature once, then expands their ACLs. In this fixture its extra
+qualification pass/materialization costs more than it saves. It is deliberately
+**not** used in production. The result does not rule out a different query or a
+different result with more expensive signatures; benchmark before changing it.
+
+## Representation and memory
+
+Wildcard grants remain compact, but removal needs concrete object/grantor
+identity. `grant_entry_grantors` is now consumed by wildcard range scans, not
+orphaned by normalization. Removing it would lose the information needed to
+revoke delegated grants safely. Owner entries carry inherent tags instead.
+
+The derivation no longer allocates an intermediate `Vec<&AclRow>`. The bounded
+path shares raw state with `Arc`, moves the derived state between phases, and
+holds a single process-wide CPU permit only during computation. Async
+query waits do not hold it; cancellation does not release it while blocking
+work is still running. The existing controller concurrency limits still bound
+how many raw snapshots can be queued; they remain serial by default.
+
+## Production-shaped validation
+
+The nightly ACL burst job runs both one- and two-worker Tokio runtimes with
+the chart's 200m CPU limit. It raises memory to 512Mi to compare bounded and
+unbounded reconciliation without an OOM truncating the comparison. A passing
+run therefore does not certify this fixture under the default 128Mi limit.
+The existing restart gate remains mandatory. Correlate its working-set samples
+with `pgroles.inspect.duration`, ACL/grantor counts, and
+`pgroles.runtime.scheduling_lag`. No digest/cache fast path is introduced.
+
+## Local runtime sample (2026-09-05)
+
+On the macOS host with PostgreSQL 18 in Docker, the final one-worker sample
+measured 197.863 ms maximum timer delay inline and 14.568 ms bounded. Process
+maximum resident set size (`/usr/bin/time -l`) was 103,792,640 bytes inline and
+103,235,584 bytes bounded. This is process RSS, not an allocation/heap profile;
+it supports no extra full snapshot copy, not a general memory reduction claim.
+Timing varies with host load. Use the low-CPU cluster gate for deployment claims.

--- a/correctness/performance/function-acl-baseline.sql
+++ b/correctness/performance/function-acl-baseline.sql
@@ -1,0 +1,16 @@
+
+        SELECT
+            grantee.rolname AS grantee,
+            acl.privilege_type,
+            n.nspname AS schema_name,
+            p.proname || '(' || pg_catalog.pg_get_function_identity_arguments(p.oid) || ')' AS object_name,
+            'function' AS obj_type,
+            pg_get_userbyid(p.proowner) AS owner_name,
+            pg_get_userbyid(acl.grantor) AS grantor
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        CROSS JOIN LATERAL aclexplode(p.proacl) AS acl
+        JOIN pg_roles grantee ON grantee.oid = acl.grantee
+        WHERE n.nspname = ANY(ARRAY['bench_1'])
+          AND grantee.rolname = ANY(ARRAY['bench_01','bench_02','bench_03','bench_04','bench_05','bench_06','bench_07','bench_08','bench_09','bench_10','bench_11','bench_12','bench_13','bench_14','bench_15','bench_16','bench_17','bench_18','bench_19','bench_20','bench_21','bench_22','bench_23','bench_24','bench_25','bench_26','bench_27','bench_28','bench_29','bench_30','bench_31','bench_32','bench_33','bench_34','bench_35','bench_36','bench_37','bench_38','bench_39','bench_40'])
+        

--- a/correctness/performance/function-acl-materialized.sql
+++ b/correctness/performance/function-acl-materialized.sql
@@ -1,0 +1,23 @@
+
+        WITH qualified AS MATERIALIZED (
+          SELECT p.proacl, p.proowner, n.nspname,
+            p.proname || '(' || pg_catalog.pg_get_function_identity_arguments(p.oid) || ')' AS object_name
+          FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE n.nspname = 'bench_1'
+            AND EXISTS (SELECT 1 FROM aclexplode(p.proacl) acl
+              JOIN pg_roles r ON r.oid = acl.grantee
+              WHERE r.rolname = ANY(ARRAY['bench_01','bench_02','bench_03','bench_04','bench_05','bench_06','bench_07','bench_08','bench_09','bench_10','bench_11','bench_12','bench_13','bench_14','bench_15','bench_16','bench_17','bench_18','bench_19','bench_20','bench_21','bench_22','bench_23','bench_24','bench_25','bench_26','bench_27','bench_28','bench_29','bench_30','bench_31','bench_32','bench_33','bench_34','bench_35','bench_36','bench_37','bench_38','bench_39','bench_40']))
+        ) SELECT
+            grantee.rolname AS grantee,
+            acl.privilege_type,
+            p.nspname AS schema_name,
+            p.object_name,
+            'function' AS obj_type,
+            pg_get_userbyid(p.proowner) AS owner_name,
+            pg_get_userbyid(acl.grantor) AS grantor
+        FROM qualified p
+        CROSS JOIN LATERAL aclexplode(p.proacl) AS acl
+        JOIN pg_roles grantee ON grantee.oid = acl.grantee
+        WHERE true
+          AND grantee.rolname = ANY(ARRAY['bench_01','bench_02','bench_03','bench_04','bench_05','bench_06','bench_07','bench_08','bench_09','bench_10','bench_11','bench_12','bench_13','bench_14','bench_15','bench_16','bench_17','bench_18','bench_19','bench_20','bench_21','bench_22','bench_23','bench_24','bench_25','bench_26','bench_27','bench_28','bench_29','bench_30','bench_31','bench_32','bench_33','bench_34','bench_35','bench_36','bench_37','bench_38','bench_39','bench_40'])
+        

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -961,9 +961,8 @@ fn diff_grants(
             .map(|(k, v)| ((&k.role, &k.schema, k.object_type), &v.privileges))
             .collect();
 
-    // Absence wildcards suppress per-name revokes for the same reason: the
-    // single `ON ALL` revoke they emit already covers every object, so a
-    // per-name revoke of the same privilege would only duplicate it.
+    // Absence wildcards collect their own concrete revokes below. Suppress
+    // the ordinary per-name path so it does not emit duplicate statements.
     let absence_wildcards: BTreeMap<(&Grantee, &Option<String>, ObjectType), &BTreeSet<Privilege>> =
         desired
             .grant_absences
@@ -1060,8 +1059,8 @@ fn diff_grants(
 
     // Absence assertions: revoke `absent ∩ current`. A wildcard assertion
     // range-scans every current key under its (grantee, type, schema) prefix,
-    // so one `ON ALL` revoke covers however many objects still hold the
-    // privilege, and an empty range is vacuously converged. Owner-inherent
+    // then expands into object/grantor-targeted revokes. An empty range is
+    // vacuously converged. Owner-inherent
     // entries are excluded throughout: an owner's privileges are intrinsic,
     // so an absence assertion cannot be enforced against them and revoking
     // would only break owner access.
@@ -1112,7 +1111,7 @@ fn diff_grants(
 /// per-grantor breakdown, emit one grantor-targeted revoke per grantor whose
 /// entry holds any of the privileges (rendered as `SET ROLE grantor`), plus a
 /// plain revoke for any remainder the breakdown does not cover. Without a
-/// breakdown — pre-existing snapshots, wildcard-collapsed keys, the desired
+/// breakdown — pre-existing snapshots or the desired
 /// side — fall back to a single plain revoke, the status quo.
 fn push_revokes_split_by_grantor(
     current: &RoleGraph,
@@ -1121,6 +1120,68 @@ fn push_revokes_split_by_grantor(
     privileges: &BTreeSet<Privilege>,
     revokes_out: &mut Vec<Change>,
 ) {
+    // Normalization compacts shared privileges, but ACL attribution remains
+    // concrete: objects in one wildcard can have different owners/grantors.
+    // Expand revokes against that inventory, never run a broad revoke as each
+    // grantor (which could touch objects it cannot administer or owner ACLs).
+    if key.name.as_deref() == Some("*") {
+        let start = GrantKey {
+            name: None,
+            ..key.clone()
+        };
+        let in_scope = |candidate: &GrantKey| {
+            candidate.role == key.role
+                && candidate.object_type == key.object_type
+                && candidate.schema == key.schema
+        };
+        let mut concrete: BTreeMap<GrantKey, BTreeSet<Privilege>> = BTreeMap::new();
+        for (target, grantors) in current
+            .grant_entry_grantors
+            .range(start.clone()..)
+            .take_while(|(target, _)| in_scope(target))
+        {
+            if target.name.as_deref() != Some("*") {
+                concrete
+                    .entry(target.clone())
+                    .or_default()
+                    .extend(grantors.values().flatten().copied());
+            }
+        }
+        for (target, state) in current
+            .grants
+            .range(start.clone()..)
+            .take_while(|(target, _)| in_scope(target))
+        {
+            if target.name.as_deref() != Some("*") {
+                concrete
+                    .entry(target.clone())
+                    .or_default()
+                    .extend(&state.privileges);
+            }
+        }
+        // An all-owner scope has no revocable grantor metadata. Its concrete
+        // inherent tags still prove that a wildcard revoke must not run.
+        let has_inherent = current
+            .inherent_grants
+            .range(start..)
+            .take_while(|target| in_scope(target))
+            .next()
+            .is_some();
+        if !concrete.is_empty() || has_inherent {
+            for (target, held) in concrete {
+                if current.inherent_grants.contains(&target) {
+                    continue;
+                }
+                let subset = privileges.intersection(&held).copied().collect();
+                if !BTreeSet::is_empty(&subset) {
+                    push_revokes_split_by_grantor(current, desired, &target, &subset, revokes_out);
+                }
+            }
+            return;
+        }
+        // Legacy/caller-built graphs without concrete inspection metadata
+        // retain their existing grantor-less behavior.
+    }
     // `ALTER SCHEMA ... OWNER TO` rewrites the ACL's attribution (old-owner
     // entries become new-owner entries), so a grantor recorded at inspection
     // time is stale once the same plan transfers the schema's owner — and a
@@ -3647,7 +3708,7 @@ memberships:
     }
 
     #[test]
-    fn wildcard_absence_emits_one_revoke_covering_every_matching_object() {
+    fn wildcard_absence_revokes_each_matching_object() {
         let mut current = RoleGraph::default();
         for name in ["f(integer)", "f(text)", "g()"] {
             current.grants.insert(
@@ -3672,14 +3733,14 @@ memberships:
         let changes = diff(&current, &desired);
         assert_eq!(
             changes,
-            vec![Change::Revoke {
-                grantor: None,
-                role: Grantee::Public,
-                privileges: [Privilege::Execute].into_iter().collect(),
-                object_type: ObjectType::Function,
-                schema: Some("api".to_string()),
-                name: Some("*".to_string()),
-            }]
+            ["f(integer)", "f(text)", "g()"]
+                .into_iter()
+                .map(|name| change_revoke(
+                    &public_function_key("api", name),
+                    &BTreeSet::from([Privilege::Execute]),
+                    None
+                ))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/pgroles-core/tests/wildcard_grantors.rs
+++ b/crates/pgroles-core/tests/wildcard_grantors.rs
@@ -1,0 +1,53 @@
+use pgroles_core::{
+    diff::{Change, diff},
+    manifest::{ObjectType, Privilege},
+    model::{GrantKey, GrantState, Grantee, RoleGraph},
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn key(name: &str) -> GrantKey {
+    GrantKey {
+        role: Grantee::Role("reader".into()),
+        object_type: ObjectType::Table,
+        schema: Some("app".into()),
+        name: Some(name.into()),
+    }
+}
+
+#[test]
+fn collapsed_revokes_use_concrete_grantors_and_preserve_owned_objects() {
+    let mut current = RoleGraph::default();
+    current.grants.insert(
+        key("*"),
+        GrantState {
+            privileges: BTreeSet::from([Privilege::Select]),
+        },
+    );
+    current.inherent_grants.insert(key("owned"));
+    for object in ["b", "a"] {
+        current.grant_entry_grantors.insert(
+            key(object),
+            BTreeMap::from([
+                ("delegate2".into(), BTreeSet::from([Privilege::Select])),
+                ("delegate1".into(), BTreeSet::from([Privilege::Select])),
+            ]),
+        );
+    }
+    let changes = diff(&current, &RoleGraph::default());
+    let expected: Vec<_> = ["a", "b"]
+        .into_iter()
+        .flat_map(|object| {
+            ["delegate1", "delegate2"]
+                .into_iter()
+                .map(move |grantor| Change::Revoke {
+                    role: Grantee::Role("reader".into()),
+                    object_type: ObjectType::Table,
+                    schema: Some("app".into()),
+                    name: Some(object.into()),
+                    grantor: Some(grantor.into()),
+                    privileges: BTreeSet::from([Privilege::Select]),
+                })
+        })
+        .collect();
+    assert_eq!(changes, expected);
+}

--- a/crates/pgroles-inspect/Cargo.toml
+++ b/crates/pgroles-inspect/Cargo.toml
@@ -16,6 +16,4 @@ pgroles-core = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-
-[dev-dependencies]
 tokio = { workspace = true }

--- a/crates/pgroles-inspect/examples/inspection_profile.rs
+++ b/crates/pgroles-inspect/examples/inspection_profile.rs
@@ -1,0 +1,72 @@
+//! Reproducible phase measurements against a disposable, pre-populated database.
+//! DATABASE_URL=... cargo run --release -p pgroles-inspect --example inspection_profile -- policy.yaml
+use pgroles_core::{
+    manifest::{expand_manifest, parse_manifest},
+    model::RoleGraph,
+};
+use pgroles_inspect::{InspectConfig, RawInspection};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::{Duration, Instant};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Run on a worker, like the operator; tokio::main's root future otherwise
+    // runs on the calling thread and hides worker starvation in inline mode.
+    tokio::spawn(profile()).await?
+}
+
+async fn profile() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let filename = std::env::args().nth(1).ok_or("expected manifest path")?;
+    let manifest = parse_manifest(&std::fs::read_to_string(filename)?)?;
+    let expanded = expand_manifest(&manifest)?;
+    let desired = RoleGraph::from_expanded(&expanded, None)?;
+    let config = InspectConfig::from_expanded(&expanded, false);
+    let pool = sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+    let lag = Arc::new(AtomicU64::new(0));
+    let measured_lag = Arc::clone(&lag);
+    let sampler = tokio::spawn(async move {
+        let mut timer = tokio::time::interval(Duration::from_millis(10));
+        timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let scheduled = timer.tick().await;
+            measured_lag.fetch_max(scheduled.elapsed().as_micros() as u64, Ordering::Relaxed);
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    for iteration in 0..5 {
+        let start = Instant::now();
+        let raw = Arc::new(RawInspection::read(&pool, &config).await?);
+        let read = start.elapsed();
+        let start = Instant::now();
+        let inspection = if std::env::var_os("PROFILE_INLINE").is_some() {
+            raw.derive(&pool, &config).await?
+        } else {
+            raw.derive_bounded(&pool, &config).await?
+        };
+        let derive = start.elapsed();
+        let start = Instant::now();
+        let changes = pgroles_core::diff::diff(&inspection.graph, &desired);
+        let diff = start.elapsed();
+        let start = Instant::now();
+        let statements: Vec<_> = changes
+            .iter()
+            .flat_map(pgroles_core::sql::render_statements)
+            .collect();
+        println!(
+            "iteration={iteration} read={read:?} derive={derive:?} diff={diff:?} render={:?} acl_rows={} grant_keys={} grantor_keys={} changes={} statements={} phases={:?}",
+            start.elapsed(),
+            inspection.stats.acl_rows,
+            inspection.stats.grants,
+            inspection.stats.grantor_keys,
+            changes.len(),
+            statements.len(),
+            inspection.stats.phase_durations
+        );
+    }
+    println!("runtime_timer_max_lag_us={}", lag.load(Ordering::Relaxed));
+    sampler.abort();
+    Ok(())
+}

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -52,6 +52,8 @@ pub use version::{PgVersion, detect_execution_role, detect_pg_version};
 
 #[derive(Debug, Error)]
 pub enum InspectError {
+    #[error("inspection derivation task failed: {0}")]
+    DerivationTask(String),
     #[error("database query error: {0}")]
     Database(#[from] sqlx::Error),
     /// A [`RawInspection`] was asked to derive an [`InspectConfig`] whose
@@ -253,6 +255,10 @@ pub struct InspectionResult {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InspectionStats {
+    /// ACL rows fetched by the shared snapshot (before per-policy filtering).
+    pub acl_rows: usize,
+    /// Concrete keys retaining the grantors needed for targeted revocation.
+    pub grantor_keys: usize,
     pub roles: usize,
     pub memberships: usize,
     pub schemas: usize,
@@ -839,7 +845,7 @@ pub async fn inspect_with_diagnostics(
     config: &InspectConfig,
 ) -> Result<InspectionResult, InspectError> {
     let raw = RawInspection::read(pool, config).await?;
-    raw.derive(pool, config).await
+    std::sync::Arc::new(raw).derive_bounded(pool, config).await
 }
 
 /// Fetch the names of all non-system schemas in the target database.

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -828,8 +828,8 @@ pub(crate) struct DerivedPrivileges {
     inherent: BTreeSet<GrantKey>,
     /// Per-grantor privilege breakdown of each grant target, from the ACL
     /// entries' recorded grantors. Keyed by the pre-normalization concrete
-    /// keys; wildcard-collapsed keys deliberately have no entry, so their
-    /// revokes fall back to grantor-less rendering.
+    /// keys, including keys compacted by wildcard normalization. The diff
+    /// range-scans these keys to expand wildcard revokes per object/grantor.
     entry_grantors: BTreeMap<GrantKey, BTreeMap<String, BTreeSet<Privilege>>>,
     /// Objects each role owns, keyed by (role, object type, schema). Wildcard
     /// normalization replaces per-name entries with `name: "*"` keys, so the
@@ -873,13 +873,12 @@ pub(crate) fn derive_privileges(
         .map(|(scope, names)| (scope.clone(), names.clone()))
         .collect();
 
-    let rows: Vec<&AclRow> = raw
+    let rows = raw
         .acl_rows
         .iter()
-        .filter(|row| row.in_scope(managed_schemas, managed_roles))
-        .collect();
+        .filter(|row| row.in_scope(managed_schemas, managed_roles));
 
-    for row in &rows {
+    for row in rows {
         if has_wildcards
             && let Some(object_type) = obj_type_str_to_object_type(&row.obj_type)
             && !matches!(object_type, ObjectType::Schema | ObjectType::Database)
@@ -891,10 +890,7 @@ pub(crate) fn derive_privileges(
                 .or_default()
                 .insert(row.object_name.clone());
         }
-    }
-    wildcard_stats.inventory_objects = inventory.values().map(BTreeSet::len).sum();
 
-    for row in rows {
         let Some(grantee) = row.grantee.as_ref() else {
             continue;
         };
@@ -958,6 +954,8 @@ pub(crate) fn derive_privileges(
         });
         entry.privileges.insert(privilege);
     }
+
+    wildcard_stats.inventory_objects = inventory.values().map(BTreeSet::len).sum();
 
     // PUBLIC state, kept only for declared scopes. Merged before wildcard
     // normalization so a present-ensure PUBLIC wildcard collapses its
@@ -1779,7 +1777,10 @@ fn normalize_wildcard_grants(
             insert_vacuous_wildcard(&mut grants, wildcard);
             continue;
         }
-        let mut shared_privileges = all_privileges();
+        // Only compact the privileges this wildcard declares. Extras must
+        // remain concrete so a named exception (for example SELECT on one
+        // table beside a wildcard INSERT) is not erased by normalization.
+        let mut shared_privileges = wildcard.privileges.clone();
 
         for object_name in object_names {
             let key = GrantKey {
@@ -1903,7 +1904,6 @@ async fn fetch_relation_privileges(
         WHERE n.nspname = ANY($1)
           AND c.relkind IN ('r', 'p', 'v', 'm', 'S')
           AND grantee.rolname = ANY($2)
-        ORDER BY n.nspname, c.relname
         "#,
     )
     .bind(managed_schemas)
@@ -1937,7 +1937,6 @@ async fn fetch_schema_privileges(
         JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
           AND grantee.rolname = ANY($2)
-        ORDER BY n.nspname
         "#,
     )
     .bind(managed_schemas)
@@ -1974,7 +1973,6 @@ async fn fetch_function_privileges(
         JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
           AND grantee.rolname = ANY($2)
-        ORDER BY n.nspname, p.proname
         "#,
     )
     .bind(managed_schemas)
@@ -2013,7 +2011,6 @@ async fn fetch_type_privileges(
           AND t.typname NOT LIKE '\_%'
           AND t.typtype <> 'p'
           AND grantee.rolname = ANY($2)
-        ORDER BY n.nspname, t.typname
         "#,
     )
     .bind(managed_schemas)
@@ -2047,7 +2044,6 @@ pub async fn fetch_database_privileges(
         JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE db.datname = current_database()
           AND grantee.rolname = ANY($1)
-        ORDER BY db.datname
         "#,
     )
     .bind(managed_roles)

--- a/crates/pgroles-inspect/src/snapshot.rs
+++ b/crates/pgroles-inspect/src/snapshot.rs
@@ -52,6 +52,25 @@ use crate::{
     remove_redundant_schema_owner_grants,
 };
 
+/// Bound CPU work across both ordinary and shared candidate inspections.
+async fn bounded_cpu<T: Send + 'static>(
+    work: impl FnOnce() -> T + Send + 'static,
+) -> Result<T, InspectError> {
+    static GATE: std::sync::OnceLock<Arc<tokio::sync::Semaphore>> = std::sync::OnceLock::new();
+    let permit = GATE
+        .get_or_init(|| Arc::new(tokio::sync::Semaphore::new(1)))
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("derivation gate never closes");
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        work()
+    })
+    .await
+    .map_err(|error| InspectError::DerivationTask(error.to_string()))
+}
+
 /// A raw, uninterpreted read of the database over one scope.
 ///
 /// Safe to derive any config whose scope is contained in the one that was
@@ -366,6 +385,19 @@ impl RawInspection {
         None
     }
 
+    /// Derive on one process-wide blocking worker, keeping CPU-heavy ACL
+    /// folding off Tokio's async workers. The permit stays with the work even
+    /// when its caller is cancelled. Arc shares the snapshot without cloning
+    /// its ACL inventory. Lazy grantability reads remain async and never hold
+    /// the CPU permit, so one stalled database cannot occupy the CPU lane.
+    pub async fn derive_bounded(
+        self: &Arc<Self>,
+        pool: &PgPool,
+        config: &InspectConfig,
+    ) -> Result<InspectionResult, InspectError> {
+        self.derive_impl(pool, config, Some(Arc::clone(self))).await
+    }
+
     /// Produce the inspection `config` would have produced on its own.
     ///
     /// Pure except for the lazy grantability read, which happens at most once
@@ -374,6 +406,15 @@ impl RawInspection {
         &self,
         pool: &PgPool,
         config: &InspectConfig,
+    ) -> Result<InspectionResult, InspectError> {
+        self.derive_impl(pool, config, None).await
+    }
+
+    async fn derive_impl(
+        &self,
+        pool: &PgPool,
+        config: &InspectConfig,
+        offload: Option<Arc<Self>>,
     ) -> Result<InspectionResult, InspectError> {
         if let Some(axis) = self.uncovered_axis(config) {
             return Err(InspectError::ScopeNotCovered(axis));
@@ -389,6 +430,7 @@ impl RawInspection {
         let mut diagnostics = InspectionDiagnostics::default();
         let mut stats = InspectionStats {
             phase_durations: self.phase_durations.clone(),
+            acl_rows: self.privileges.acl_rows.len() + self.privileges.public_acl_rows.len(),
             ..InspectionStats::default()
         };
 
@@ -454,20 +496,49 @@ impl RawInspection {
         // A PUBLIC rule names its own target, so one aimed at the database
         // carries no schema and must still be derived.
         if !privilege_schemas.is_empty() || !config.public_object_scopes.is_empty() {
-            let derived = privileges::derive_privileges(
-                &self.privileges,
-                &privilege_schemas,
-                &managed_roles,
-                &config.wildcard_grants,
-                &config.public_object_scopes,
-            );
+            let derive_started = Instant::now();
+            let derived = if let Some(snapshot) = offload.as_ref() {
+                let snapshot = Arc::clone(snapshot);
+                let schemas = privilege_schemas.clone();
+                let roles = managed_roles.clone();
+                let config = config.clone();
+                bounded_cpu(move || {
+                    privileges::derive_privileges(
+                        &snapshot.privileges,
+                        &schemas,
+                        &roles,
+                        &config.wildcard_grants,
+                        &config.public_object_scopes,
+                    )
+                })
+                .await?
+            } else {
+                privileges::derive_privileges(
+                    &self.privileges,
+                    &privilege_schemas,
+                    &managed_roles,
+                    &config.wildcard_grants,
+                    &config.public_object_scopes,
+                )
+            };
+            stats
+                .phase_durations
+                .insert("privilege_derive", derive_started.elapsed());
             let (grantability, read_performed) = if derived.unsatisfied.is_empty() {
                 (None, false)
             } else {
                 let (raw, fetched) = self.grantability(pool).await?;
                 (Some(raw), fetched)
             };
-            let result = derived.finish(grantability.as_deref(), read_performed);
+            let finish_started = Instant::now();
+            let result = if offload.is_some() {
+                bounded_cpu(move || derived.finish(grantability.as_deref(), read_performed)).await?
+            } else {
+                derived.finish(grantability.as_deref(), read_performed)
+            };
+            stats
+                .phase_durations
+                .insert("privilege_normalize", finish_started.elapsed());
 
             stats.wildcard = result.wildcard_stats;
             diagnostics
@@ -477,7 +548,8 @@ impl RawInspection {
                 graph.grants.insert(key, state);
             }
             graph.inherent_grants.extend(result.inherent);
-            graph.grant_entry_grantors.extend(result.entry_grantors);
+            graph.grant_entry_grantors = result.entry_grantors;
+            stats.grantor_keys = graph.grant_entry_grantors.len();
             remove_redundant_schema_owner_grants(&mut graph);
             stats.grants = graph.grants.len();
 
@@ -644,6 +716,52 @@ mod tests {
             owner_has_create: true,
             owner_has_usage: true,
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bounded_derivation_works_on_a_single_worker_without_copying_snapshot() {
+        let snapshot = Arc::new(snapshot());
+        let config = config(&["alice"], &["app"], false, vec![]);
+        let expected = snapshot.derive(&unreachable_pool(), &config).await.unwrap();
+        let result = snapshot
+            .derive_bounded(&unreachable_pool(), &config)
+            .await
+            .unwrap();
+        assert_eq!(result.graph.grants, expected.graph.grants);
+        assert_eq!(Arc::strong_count(&snapshot), 1);
+    }
+
+    #[test]
+    fn shuffled_acl_rows_preserve_graph_and_diagnostics() {
+        let mut snapshot = snapshot();
+        let mut scope = config(
+            &["alice"],
+            &["app"],
+            false,
+            vec![WildcardGrantPattern {
+                role: "alice".into(),
+                object_type: ObjectType::Table,
+                schema: "app".into(),
+                privileges: BTreeSet::from([Privilege::Select]),
+            }],
+        );
+        scope.public_object_scopes = vec![public_scope("app", "widgets", &[Privilege::Select])];
+        let expected = derive_pure(&snapshot, &scope);
+        snapshot.privileges.acl_rows.reverse();
+        snapshot.privileges.public_acl_rows.reverse();
+        snapshot.roles.reverse();
+        snapshot.memberships.reverse();
+        let actual = derive_pure(&snapshot, &scope);
+        assert_eq!(actual.graph.grants, expected.graph.grants);
+        assert_eq!(actual.graph.inherent_grants, expected.graph.inherent_grants);
+        assert_eq!(
+            actual.graph.grant_entry_grantors,
+            expected.graph.grant_entry_grantors
+        );
+        assert_eq!(actual.graph.memberships, expected.graph.memberships);
+        assert!(pgroles_core::diff::diff(&actual.graph, &expected.graph).is_empty());
+        assert!(pgroles_core::diff::diff(&expected.graph, &actual.graph).is_empty());
+        assert_eq!(actual.diagnostics, expected.diagnostics);
     }
 
     fn table_acl(schema: &str, table: &str, grantee: &str, privilege: &str) -> AclRow {

--- a/crates/pgroles-inspect/tests/grantor_targeted_revokes_live.rs
+++ b/crates/pgroles-inspect/tests/grantor_targeted_revokes_live.rs
@@ -670,3 +670,100 @@ fn pure_addition_acquires_defaults_owner_authority() {
         assert!(replan.is_empty(), "must converge in one apply: {replan:?}");
     });
 }
+
+/// Wildcard convergence must address both delegates on every concrete object,
+/// preserving owner privileges and named exceptions.
+#[test]
+#[ignore]
+fn wildcard_revokes_keep_concrete_grantors_and_converge() {
+    with_runtime(async {
+        let pool = PgPool::connect(&database_url()).await.unwrap();
+        pool.execute("DROP SCHEMA IF EXISTS wgr CASCADE; \
+          DROP ROLE IF EXISTS wgr_exec; DROP ROLE IF EXISTS wgr_reader; DROP ROLE IF EXISTS wgr_a; DROP ROLE IF EXISTS wgr_b; \
+          CREATE ROLE wgr_exec LOGIN PASSWORD 'wgr_test_password'; CREATE ROLE wgr_reader; CREATE ROLE wgr_a; CREATE ROLE wgr_b; \
+          CREATE SCHEMA wgr; GRANT USAGE ON SCHEMA wgr TO PUBLIC; \
+          CREATE TABLE wgr.t(i int); CREATE TABLE wgr.u(i int); \
+          GRANT SELECT ON ALL TABLES IN SCHEMA wgr TO wgr_a, wgr_b WITH GRANT OPTION; \
+          GRANT INSERT ON ALL TABLES IN SCHEMA wgr TO wgr_reader; \
+          SET ROLE wgr_a; GRANT SELECT ON ALL TABLES IN SCHEMA wgr TO wgr_reader, PUBLIC; RESET ROLE; \
+          SET ROLE wgr_b; GRANT SELECT ON ALL TABLES IN SCHEMA wgr TO wgr_reader, PUBLIC; RESET ROLE;")
+          .await.unwrap();
+        let manifest = "roles:\n  - name: wgr_reader\ngrants:\n  - role: wgr_reader\n    privileges: [INSERT]\n    object: {type: table, schema: wgr, name: '*'}\n  - role: PUBLIC\n    ensure: absent\n    privileges: [SELECT]\n    object: {type: table, schema: wgr, name: '*'}\n";
+        let changes = plan(&pool, manifest).await;
+        let revokes: Vec<_> = changes
+            .iter()
+            .filter(|c| matches!(c, Change::Revoke { .. }))
+            .collect();
+        assert_eq!(
+            revokes.len(),
+            8,
+            "two grantors x two objects x two grantees: {changes:?}"
+        );
+        assert!(revokes.iter().all(
+            |c| matches!(c, Change::Revoke {name: Some(n), grantor: Some(_), ..} if n != "*")
+        ));
+        assert!(filter_changes(changes.clone(), ReconciliationMode::Additive).is_empty());
+        assert!(
+            preflight_authority_issues(&pool, &changes, &RoleGraph::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let exec = PgPool::connect_with(
+            PgConnectOptions::from_str(&database_url())
+                .unwrap()
+                .username("wgr_exec")
+                .password("wgr_test_password"),
+        )
+        .await
+        .unwrap();
+        let denied = preflight_authority_issues(&exec, &changes, &RoleGraph::default())
+            .await
+            .unwrap();
+        assert!(
+            !denied.is_empty(),
+            "missing grantor authority must block apply"
+        );
+        pool.execute("GRANT wgr_a, wgr_b TO wgr_exec")
+            .await
+            .unwrap();
+        assert!(
+            preflight_authority_issues(&exec, &changes, &RoleGraph::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        apply(&exec, &changes).await;
+        assert!(plan(&pool, manifest).await.is_empty());
+        // A wildcard spanning owned and delegated objects must preserve the
+        // owner's ACL while removing the undeclared privilege on the other.
+        pool.execute("ALTER TABLE wgr.t OWNER TO wgr_reader; SET ROLE wgr_a; GRANT SELECT ON wgr.u TO wgr_reader; RESET ROLE").await.unwrap();
+        let mixed = plan(&pool, manifest).await;
+        assert!(
+            mixed
+                .iter()
+                .all(|c| matches!(c, Change::Revoke {name: Some(n), ..} if n == "u")),
+            "{mixed:?}"
+        );
+        assert_eq!(mixed.len(), 1);
+        apply(&pool, &mixed).await;
+        assert!(plan(&pool, manifest).await.is_empty());
+        let (owner_select,): (bool,) =
+            sqlx::query_as("SELECT has_table_privilege('wgr_reader', 'wgr.t', 'SELECT')")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(owner_select);
+        // A named exception next to a wildcard must remain granted and
+        // produce an empty replan, even when all objects once held SELECT.
+        pool.execute("SET ROLE wgr_a; GRANT SELECT ON wgr.u TO wgr_reader; RESET ROLE")
+            .await
+            .unwrap();
+        let exception = format!(
+            "{manifest}  - role: wgr_reader\n    privileges: [SELECT]\n    object: {{type: table, schema: wgr, name: u}}\n"
+        );
+        assert!(plan(&pool, &exception).await.is_empty());
+        exec.close().await;
+        pool.execute("DROP SCHEMA wgr CASCADE; DROP OWNED BY wgr_reader, wgr_a, wgr_b; DROP ROLE wgr_exec, wgr_reader, wgr_a, wgr_b").await.unwrap();
+    });
+}

--- a/crates/pgroles-operator/src/candidate.rs
+++ b/crates/pgroles-operator/src/candidate.rs
@@ -515,7 +515,7 @@ struct SharedInspection {
     /// `None` when there was nothing to share (no plannable candidate on the
     /// parent's own target) or when the shared read failed — in which case
     /// every candidate falls back to inspecting for itself, exactly as before.
-    raw: Option<pgroles_inspect::RawInspection>,
+    raw: Option<std::sync::Arc<pgroles_inspect::RawInspection>>,
     /// Database inspections performed during this pass: the shared read counts
     /// as one, and each fallback adds another. This is the number the issue
     /// asks to bound, so it is measured rather than assumed. (The at-most-one
@@ -552,7 +552,7 @@ impl SharedInspection {
             && let Some(raw) = self.raw.as_ref()
             && raw.covers(config)
         {
-            return Ok(raw.derive(target.pool(), config).await?);
+            return Ok(raw.derive_bounded(target.pool(), config).await?);
         }
 
         self.inspections
@@ -605,7 +605,7 @@ async fn shared_inspection(
     let union = pgroles_inspect::InspectConfig::union_of(configs.iter());
     match pgroles_inspect::RawInspection::read(planning.pool, &union).await {
         Ok(raw) => SharedInspection {
-            raw: Some(raw),
+            raw: Some(std::sync::Arc::new(raw)),
             inspections: std::sync::atomic::AtomicUsize::new(1),
             plannable,
         },

--- a/crates/pgroles-operator/src/observability.rs
+++ b/crates/pgroles-operator/src/observability.rs
@@ -1,5 +1,6 @@
 //! Operator health endpoints and OTLP metrics export.
 
+use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,6 +34,8 @@ struct Metrics {
     reconcile_duration_ms: Histogram<u64>,
     reconcile_inflight: UpDownCounter<i64>,
     inspect_duration_ms: Histogram<u64>,
+    processing_duration_ms: Histogram<f64>,
+    scheduling_lag_ms: Histogram<f64>,
     inspect_items_total: Counter<u64>,
     wildcard_grantability_queries_total: Counter<u64>,
     wildcard_unsatisfied_grants_total: Counter<u64>,
@@ -169,6 +172,15 @@ impl OperatorObservability {
         }
     }
 
+    pub fn record_processing_phase(&self, phase: &'static str, duration: Duration) {
+        if let Some(metrics) = &self.metrics {
+            metrics.processing_duration_ms.record(
+                duration.as_secs_f64() * 1000.0,
+                &[KeyValue::new("phase", phase)],
+            );
+        }
+    }
+
     pub fn record_inspection(&self, stats: &pgroles_inspect::InspectionStats) {
         let Some(metrics) = &self.metrics else {
             return;
@@ -186,6 +198,8 @@ impl OperatorObservability {
             ("memberships", stats.memberships),
             ("schemas", stats.schemas),
             ("grants", stats.grants),
+            ("acl_rows", stats.acl_rows),
+            ("grantor_keys", stats.grantor_keys),
             ("default_privileges", stats.default_privileges),
             (
                 "wildcard_configured_grants",
@@ -420,9 +434,24 @@ pub async fn serve_health(
     let app = Router::new()
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
-        .with_state(observability);
+        .with_state(observability.clone());
 
-    serve(listener, app).await?;
+    let lag = async {
+        let mut timer = tokio::time::interval(Duration::from_secs(1));
+        timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let scheduled = timer.tick().await;
+            if let Some(metrics) = &observability.metrics {
+                metrics
+                    .scheduling_lag_ms
+                    .record(scheduled.elapsed().as_secs_f64() * 1000.0, &[]);
+            }
+        }
+    };
+    tokio::select! {
+        result = serve(listener, app).into_future() => { result?; }
+        () = lag => {}
+    }
     Ok(())
 }
 
@@ -511,6 +540,16 @@ impl Metrics {
             reconcile_inflight: meter
                 .i64_up_down_counter("pgroles.reconcile.inflight")
                 .with_description("In-flight reconciliations")
+                .build(),
+            processing_duration_ms: meter
+                .f64_histogram("pgroles.processing.duration")
+                .with_unit("ms")
+                .with_description("Synchronous policy processing by phase")
+                .build(),
+            scheduling_lag_ms: meter
+                .f64_histogram("pgroles.runtime.scheduling_lag")
+                .with_unit("ms")
+                .with_description("Delay of a one-second runtime timer; not HTTP probe latency")
                 .build(),
             inspect_duration_ms: meter
                 .u64_histogram("pgroles.inspect.duration")
@@ -775,6 +814,8 @@ mod tests {
         observability.record_invalid_spec();
         observability.record_database_connection_failure();
         observability.record_inspection(&pgroles_inspect::InspectionStats {
+            acl_rows: 20,
+            grantor_keys: 5,
             roles: 3,
             memberships: 2,
             schemas: 1,
@@ -796,6 +837,7 @@ mod tests {
                 grantability_objects: 3,
             },
         });
+        observability.record_processing_phase("diff", Duration::from_millis(3));
         observability.record_plan_result("drift");
         observability.record_planned_changes(2);
         observability.record_candidate_planning(Duration::from_millis(37));
@@ -822,6 +864,7 @@ mod tests {
         assert!(metric_exists(&metrics, "pgroles.reconcile.total"));
         assert!(metric_exists(&metrics, "pgroles.reconcile.duration"));
         assert!(metric_exists(&metrics, "pgroles.inspect.duration"));
+        assert!(metric_exists(&metrics, "pgroles.processing.duration"));
         assert!(metric_exists(
             &metrics,
             "pgroles.candidate.planning.duration"
@@ -829,7 +872,7 @@ mod tests {
         // A histogram, not a counter — the interesting value is the
         // inspections-per-pass distribution, so there is no sum to assert on.
         assert!(metric_exists(&metrics, "pgroles.candidate.inspections"));
-        assert_eq!(u64_sum_value(&metrics, "pgroles.inspect.items"), Some(119));
+        assert_eq!(u64_sum_value(&metrics, "pgroles.inspect.items"), Some(144));
         assert_eq!(
             u64_sum_value(&metrics, "pgroles.ephemeral_access.transitions"),
             Some(2)

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -663,6 +663,7 @@ pub async fn create_or_update_plan(
     // 1. Render the full executable SQL (not redacted). This is a review
     //    artifact only — never an execution payload, and never the approval
     //    identity.
+    let render_started = std::time::Instant::now();
     let full_sql = render_full_sql(changes, sql_context);
 
     // 2. Compute the approval identity: a canonical digest of the typed
@@ -687,6 +688,13 @@ pub async fn create_or_update_plan(
 
     // 5. Render redacted SQL for display (passwords masked).
     let redacted_sql = render_redacted_sql(changes, sql_context);
+    tracing::debug!(
+        phase = "plan_render",
+        elapsed_ms = render_started.elapsed().as_secs_f64() * 1000.0,
+        changes = changes.len(),
+        sql_bytes = full_sql.len(),
+        "plan processing phase"
+    );
 
     // Candidate plans are pruned by candidate retention (their owner cascades),
     // never by the policy's plan retention, which would not see them anyway.

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -672,6 +672,7 @@ fn inspect_error_is_non_transient(error: &pgroles_inspect::InspectError) -> bool
         // A scope the shared snapshot never read: a programming error in the
         // caller, not something a retry can fix.
         pgroles_inspect::InspectError::ScopeNotCovered(_)
+        | pgroles_inspect::InspectError::DerivationTask(_)
         | pgroles_inspect::InspectError::DatabaseTargetMismatch { .. } => true,
     }
 }
@@ -1428,6 +1429,7 @@ async fn apply_under_lock(
              use adopt or authoritative mode to enforce absence"
         );
     }
+    let diff_started = std::time::Instant::now();
     let mut changes = pgroles_core::diff::filter_changes(
         pgroles_core::diff::apply_role_retirements(
             pgroles_core::diff::diff(&current, &effective_desired),
@@ -1471,6 +1473,9 @@ async fn apply_under_lock(
     {
         return Err(ReconcileError::OwnerTransferBlocked(blocker));
     }
+
+    ctx.observability
+        .record_processing_phase("diff", diff_started.elapsed());
 
     let resolved_passwords = resolve_passwords_from_secrets(ctx, resource, namespace).await?;
     let (password_changes, mut applied_password_source_versions) =
@@ -1523,7 +1528,10 @@ async fn apply_under_lock(
         Some(message)
     };
 
+    let summary_started = std::time::Instant::now();
     let summary = summarize_changes(&changes);
+    ctx.observability
+        .record_processing_phase("summary", summary_started.elapsed());
     let sql_ctx = detect_sql_context(pool, &inspect_config).await?;
 
     let effective_approval = resource.spec.effective_approval();
@@ -3589,7 +3597,8 @@ impl ReconcileError {
                         SqlErrorKind::Transient => "DatabaseInspectionFailed",
                     }
                 }
-                pgroles_inspect::InspectError::ScopeNotCovered(_) => "DatabaseInspectionFailed",
+                pgroles_inspect::InspectError::ScopeNotCovered(_)
+                | pgroles_inspect::InspectError::DerivationTask(_) => "DatabaseInspectionFailed",
                 pgroles_inspect::InspectError::DatabaseTargetMismatch { .. } => {
                     "InvalidDatabaseTarget"
                 }

--- a/crates/pgroles-operator/tests/doc_manifests.rs
+++ b/crates/pgroles-operator/tests/doc_manifests.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 
 use jsonschema::Validator;
 use kube::CustomResourceExt;
-use pgroles_core::manifest::parse_manifest;
+use pgroles_core::manifest::{expand_manifest, parse_manifest};
 use pgroles_operator::crd::{
     EphemeralAccessPolicy, EphemeralAccessRequest, PostgresPolicy, PostgresPolicyPlan,
     postgres_policy_candidate_crd,
@@ -314,6 +314,20 @@ fn doc_manifests_match_generated_crd_schemas() {
                 };
 
                 checked += 1;
+                // JSON Schema cannot execute Kubernetes CEL. Also run the
+                // shared semantic validator for policy content, including
+                // constraints such as database targets requiring a name.
+                let content = match kind {
+                    "PostgresPolicy" => value.get("spec"),
+                    "PostgresPolicyCandidate" => value.pointer("/spec/content"),
+                    _ => None,
+                };
+                if let Some(content) = content {
+                    let yaml = serde_yaml::to_string(content).expect("content should serialize");
+                    if let Err(error) = parse_manifest(&yaml).and_then(|m| expand_manifest(&m)) {
+                        failures.push(format!("{name}: {kind} invalid policy content: {error}"));
+                    }
+                }
                 for error in validator.iter_errors(&value) {
                     let path = error.instance_path().to_string();
                     let path = if path.is_empty() { "<root>" } else { &path };

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -49,6 +49,7 @@ const navigation = [
             {title: 'Plan and approval', href: '/docs/operator-plan-approval'},
             {title: 'Candidates and promotion', href: '/docs/operator-candidates'},
             {title: 'Running the operator', href: '/docs/operator-operations'},
+            {title: 'Upgrading', href: '/docs/operator-upgrades'},
             {title: 'Status and telemetry', href: '/docs/operator-status'},
             {title: 'Troubleshooting index', href: '/docs/operator-troubleshooting'},
             {title: 'RBAC and security', href: '/docs/operator-security'},

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -54,7 +54,7 @@ Run `pgroles diff` locally to review changes before enabling apply:
 pgroles diff --database-url $DATABASE_URL -f pgroles.yaml --mode additive
 ```
 
-If the output is `-- No changes needed`, the manifest matches the database and apply will be a no-op.
+If the output is `-- No changes needed`, there are no pending changes within additive mode. Undeclared access and pre-existing attributes may still differ.
 
 ### 4. Enable additive apply
 
@@ -67,11 +67,15 @@ spec:
   reconciliation_mode: additive
 ```
 
-### 5. Progress to authoritative (optional)
+### 5. Adopt declared roles
 
-Once the manifest covers all roles and grants you want managed, switch to `reconciliation_mode: authoritative` to enable full convergence. Review the planned revocations carefully before switching — in a typical brownfield database, this may include thousands of existing grants to roles not yet in the manifest.
+Preview with `pgroles diff --mode adopt -f pgroles.yaml`. Adopt retains revocations and membership removals, but filters role drops and retirement steps. Review every removal and verify application access before setting `reconciliation_mode: adopt`. You can stay in adopt mode permanently.
 
 Roles whose grant surface is known but not yet fully declared can be onboarded safely with `preserve_undeclared_grants: true` — see [preserving undeclared grants](/docs/manifest-reference#preserving-undeclared-grants). Adopt mode additionally refuses to transfer schema ownership unless `--allow-schema-owner-transfers` is passed (CLI) or `spec.allow_schema_owner_transfers: true` is set (operator) — reviewing or approving a plan does not bypass the guard.
+
+### 6. Authoritative control (optional)
+
+Use authoritative mode when your policy should also retire eligible roles in its managed scope. Preview `pgroles diff --mode authoritative -f pgroles.yaml`, review explicit retirements and their side effects, then change the operator mode. This does not give pgroles ownership of every role in the database.
 
 ## Multi-team adoption with bundles
 

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -8,6 +8,10 @@ description: How to install the pgroles CLI tool.
 - **PostgreSQL 16, 17, 18**: Supported and tested in CI, including per-membership `INHERIT` and `ADMIN` options
 - **Earlier PostgreSQL releases**: Unsupported
 
+## Released binaries
+
+Download the binary for your platform from the [latest stable release](https://github.com/thepartly/pgroles/releases/latest). Keep the CLI version aligned with the release documentation and any scripts that consume its JSON output.
+
 ## From source
 
 pgroles is written in Rust. Build and install with Cargo:
@@ -48,35 +52,6 @@ Published container images are multi-arch for `linux/amd64` and `linux/arm64`.
 The release workflow builds the Linux binaries first and then assembles the
 runtime images from those artifacts, so published images do not recompile Rust
 inside the Docker publish jobs.
-
-## Local Docker validation
-
-To reproduce the live CLI tests against a local PostgreSQL:
-
-```shell
-docker run --rm --name pgroles-pg18 \
-  -e POSTGRES_PASSWORD=testpassword \
-  -e POSTGRES_DB=pgroles_test \
-  -p 5432:5432 \
-  postgres:18
-```
-
-In another shell:
-
-```shell
-export DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test
-cargo test -p pgroles-cli --test cli live_db::diff_against_live_db -- --ignored --exact
-cargo test -p pgroles-cli --test cli live_db::diff_summary_format -- --ignored --exact
-```
-
-Use `postgres:16` or `postgres:17` if you want to reproduce the full CI matrix locally.
-
-## Contributor notes
-
-- `docker/Dockerfile` is the source-build path used for local builds and E2E-style flows.
-- `docker/Dockerfile.runtime` is the release assembly path used in GitHub Actions.
-- BuildKit cache mounts are used in `docker/Dockerfile` for Cargo registry, git, and target caches.
-- The release workflow does not need Cargo cache mounts in the Docker step because it consumes prebuilt Linux binaries from the earlier build job.
 
 ## Verify installation
 

--- a/docs/src/pages/docs/limitations.md
+++ b/docs/src/pages/docs/limitations.md
@@ -23,12 +23,30 @@ The manifest does not model `WITH GRANT OPTION` for application grantees. pgrole
 
 Delegation also constrains what a `REVOKE` can do, because PostgreSQL attributes every grant to a grantor and a plain revoke removes only grants attributed to the revoker (see the upstream [REVOKE](https://www.postgresql.org/docs/current/sql-revoke.html) and [GRANT](https://www.postgresql.org/docs/current/sql-grant.html) documentation): "a user can only revoke privileges that were granted directly by that user", and a superuser's revoke "is performed as though it were issued by the owner of the affected object" — for role memberships (PostgreSQL 16+, which records a grantor per edge), by the bootstrap superuser. A plain revoke matching no such entry **succeeds silently** (object privileges) or with only a `WARNING` (memberships), leaving the grant in place.
 
-pgroles therefore plans revokes **per recorded grantor**. Inspection reads each ACL entry's and membership edge's grantor — including entries whose grantee is `PUBLIC`, which a grant-option holder can also create — and the rendered SQL acts as that grantor: object revokes run as `SET ROLE grantor; REVOKE ...;` inside the plan's single transaction (object `GRANTED BY` must name the current user), then restore the connection's configured execution role (the operator's `connection.params.setRole`, or the login role when none is set); membership revokes run as `REVOKE ... GRANTED BY grantor`. A delegate-granted privilege or a foreign-admin membership edge converges like any other, provided the executor can become the grantor:
+pgroles plans object revokes per concrete object and recorded grantor, including
+wildcard rules and PUBLIC. It runs each revoke as `SET ROLE <grantor>` inside the
+apply transaction, then restores the configured execution role. Membership
+revokes use `REVOKE ... GRANTED BY <grantor>`.
 
-- for **object revokes**, membership in the grantor with the `SET` option (PostgreSQL 16's default on granted memberships) — superusers can become anyone;
-- for **membership revokes**, the privileges of the grantor (membership with inheritance) — superusers hold every role's privileges.
+| Operation | Executor authority required |
+| --- | --- |
+| Object revoke | Ability to `SET ROLE` to each recorded grantor |
+| Membership revoke | Usable privileges of each recorded grantor, through inheritance |
 
-The plan preflight verifies exactly that, per grantor, and reports what the executor is missing (`UnsatisfiableRevoke`: warning on `diff`, blocking on `apply`). Because everything executes in one transaction, the preflight also checks authority against the plan's own execution order: object revokes run before membership removals, and later statements are judged against a conservative approximation of the membership graph at their phase — membership revokes see the whole removal batch applied at once, and additions that reference roles the same plan creates are ignored. A `GRANTED BY` membership revoke whose grantor path the plan's removals strip is flagged rather than left to fail mid-apply (split such a removal into a separate, later apply); a default-privilege revoke runs after the plan's own membership additions, so a path the plan replaces or newly acquires — say, an admin-only executor granting the owner to a role it already inherits — counts and is not falsely rejected. Object-ACL grantors are recorded on every supported version; membership-edge grantors exist only since PostgreSQL 16, so membership revokes on older servers — and object revokes for wildcard-collapsed grant keys — fall back to the plain revoke, and the operator's post-apply detection — a plan whose exact effects were just applied yet still diff, reported as `Ready=False` with reason `NonConvergentPlan` — remains the backstop for anything attribution-shaped that slips through.
+Preflight reports `UnsatisfiableRevoke` when that authority is missing: `diff`
+warns and `apply` blocks. It checks authority against the plan's execution order,
+so removing a membership cannot silently invalidate a later statement's authority.
+
+Wildcard revocations expand to concrete changes because different objects may
+have different owners and grantors. Owner-inherent privileges are preserved.
+The plan can therefore contain more entries than the wildcard rules in the
+manifest; review its complete SQL. This behavior ships in the next release after
+0.10.1. In 0.10.0–0.10.1, wildcard-collapsed revokes can fall back to a plain revoke
+and leave delegated entries behind; see [#215](https://github.com/thepartly/pgroles/issues/215).
+
+If identical effects remain after apply, the operator reports `NonConvergentPlan`
+and retries at the policy interval. Investigate the retained ACL and authority
+instead of repeatedly approving the same changes.
 
 More generally, pgroles converges managed direct ACLs; it does not claim that absence from a manifest means absence of effective access. Membership, ownership, `PUBLIC`, column grants, row security, or unmodeled object types may change the answer. Use PostgreSQL's `has_*_privilege` and `pg_has_role` functions to verify the effective path. Work through [The permission chain](/docs/postgresql-access-model) and [The security review](/docs/postgresql-security-review) to test those paths interactively.
 

--- a/docs/src/pages/docs/operator-candidates.md
+++ b/docs/src/pages/docs/operator-candidates.md
@@ -7,18 +7,17 @@ Review what a change would do to production before it becomes the desired state.
 
 ---
 
-{% callout type="note" title="What is not built" %}
-The kind, the content digest, the planning lifecycle, **promotion** (the
-subject of this page), and the `pgroles candidate` CLI subcommands are
-implemented. Two things named below are not: `pgroles plan`, and
-`spec.contentRef` for content too large to embed.
+## The review loop
 
-Every recipe on this page is given twice, as `kubectl` and as `pgroles
-candidate`. The `kubectl` form is not a fallback: it is the definition, and it
-is what you use where the CLI is not installed. **Deciding** a plan has only
-the `kubectl` form; this is deliberate (see [Reviewing and
-deciding](#reviewing-and-deciding)).
-{% /callout %}
+1. Create a candidate from the **complete proposed content**, while the parent keeps enforcing.
+2. Read its plan with `pgroles candidate status` and `pgroles candidate diff`.
+3. Approve that plan using the authenticated status-decision workflow.
+4. Merge exactly the reviewed content into the parent policy.
+5. Verify the plan is Applied and the parent has converged. If the effects changed, review the replacement plan.
+
+Approval alone never promotes or executes a candidate. The sections below give
+commands for each step, followed by lifecycle and recovery details.
+
 
 ## What a candidate is
 

--- a/docs/src/pages/docs/operator-install.md
+++ b/docs/src/pages/docs/operator-install.md
@@ -92,3 +92,5 @@ requires patching the Deployment.
 - Ensure the management role can grant every wildcard-managed privilege on every matching object, either by owning those objects or holding the required `WITH GRANT OPTION`.
 - Validate and review the manifest with the CLI before handing it to the operator.
 - Treat deletion as "stop managing", not "revert the database".
+
+For the complete version-matched procedure and 0.10 migration checklist, see [upgrading the operator](/docs/operator-upgrades).

--- a/docs/src/pages/docs/operator-operations.md
+++ b/docs/src/pages/docs/operator-operations.md
@@ -38,6 +38,25 @@ operator:
 
 Use a positive integer for bounded concurrency. `0` restores kube-rs's unbounded behavior and should be reserved for controlled troubleshooting. An invalid value prevents the operator from starting and names `RECONCILE_CONCURRENCY` in the error.
 
+### Measuring expensive policies
+
+Inspection metrics include raw `acl_rows`, final `grants`, and concrete
+`grantor_keys` under `pgroles.inspect.items`. These are observed counts, not
+unique-object totals across reconciles. `pgroles.inspect.duration` separates
+`privilege_derive` and `privilege_normalize` from catalog reads.
+`pgroles.processing.duration` reports diff and summary construction.
+Debug logs report plan rendering time and SQL bytes without logging SQL.
+
+`pgroles.runtime.scheduling_lag` measures delay of a one-second runtime timer.
+It helps identify async-worker starvation; it is **not** HTTP health-probe
+latency. Correlate it with container CPU throttling, working set, and restarts.
+
+ACL derivation runs on one bounded blocking worker per process. Concurrent
+callers share snapshots through `Arc`; increasing reconcile concurrency does
+not increase the number of simultaneous derivations. It can still increase
+memory held by reads and queued snapshots. Keep the serial default on small
+CPU allocations and validate the complete workload before raising it.
+
 ## Interval
 
 The `interval` field controls how often the operator re-reconciles, even when the resource hasn't changed. This catches drift from manual SQL changes. Supports durations like `30s`, `5m`, `1h`, or compound forms like `1h30m`. Defaults to `5m`.

--- a/docs/src/pages/docs/operator-production-status.md
+++ b/docs/src/pages/docs/operator-production-status.md
@@ -37,7 +37,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 **API stability:**
 
-- The CRD is `v1alpha1`. There is no conversion webhook, no migration tooling, and no documented upgrade path between versions.
+- The CRD is `v1alpha1`. There is no conversion webhook, no migration tooling. Follow the [upgrade guide](/docs/operator-upgrades) and review each release's compatibility notes.
 - Controller semantics that should be part of the API contract are implementation-only conventions.
 
 **Scale and HA:**

--- a/docs/src/pages/docs/operator-quick-start.md
+++ b/docs/src/pages/docs/operator-quick-start.md
@@ -48,7 +48,8 @@ kubectl get pods -n pgroles-system \
   -l app.kubernetes.io/instance=pgroles-operator
 ```
 
-The chart installs four CRDs: `PostgresPolicy`, `PostgresPolicyPlan`, and the
+The chart installs five CRDs: `PostgresPolicy`, `PostgresPolicyPlan`,
+`PostgresPolicyCandidate`, and the
 `EphemeralAccessPolicy` / `EphemeralAccessRequest` pair behind
 [ephemeral access](/docs/ephemeral-access). The operator watches every namespace
 unless `operator.watchNamespace` scopes it to one.
@@ -106,7 +107,7 @@ spec:
 
   grants:
     - role: pgroles_quickstart_reader
-      object: { type: database }
+      object: { type: database, name: app }
       privileges: [CONNECT]
 ```
 

--- a/docs/src/pages/docs/operator-upgrades.md
+++ b/docs/src/pages/docs/operator-upgrades.md
@@ -1,0 +1,78 @@
+---
+title: Upgrading the operator
+description: Upgrade version-matched CRDs and the controller, review changed approvals, and verify convergence.
+---
+
+Upgrade the API and controller as one reviewed change. {% .lead %}
+
+## Before upgrading
+
+Read the target release's upgrade notes. Save your current chart version, values,
+and policy manifests in your deployment repository. Keep database recovery
+procedures separate: rolling back a controller does not reverse committed SQL.
+
+Set the exact release you reviewed, for example `VERSION=0.10.1`. Render and
+review its resources using your existing values:
+
+```bash
+VERSION=0.10.1
+helm template pgroles-operator oci://ghcr.io/thepartly/charts/pgroles-operator \
+  --version "$VERSION" --namespace pgroles-system --include-crds \
+  --values values.yaml > operator-rendered.yaml
+```
+
+Check the image, resource limits, admission policies, and CRD changes. The API is
+`v1alpha1` with no conversion webhook. Do not assume an older controller can read
+newer resources or approvals.
+
+## Update CRDs, then the controller
+
+Helm installs CRDs but does not upgrade them. Extract the CRDs from the **same
+chart version**, inspect the diff, then apply them before upgrading:
+
+```bash
+set -euo pipefail
+helm show crds oci://ghcr.io/thepartly/charts/pgroles-operator \
+  --version "$VERSION" > operator-crds.yaml
+test -s operator-crds.yaml
+kubectl diff --server-side -f operator-crds.yaml
+```
+
+`kubectl diff` exits 1 when differences exist. After reviewing them, run:
+
+```bash
+kubectl apply --server-side -f operator-crds.yaml
+helm upgrade pgroles-operator oci://ghcr.io/thepartly/charts/pgroles-operator \
+  --version "$VERSION" --namespace pgroles-system --values values.yaml --wait
+```
+
+## Moving from 0.9 to 0.10
+
+- Open plans need fresh approval because the effect digest encoding changed to
+  v3. Inspect replacement plans; old decisions do not transfer.
+- Replace deprecated `mode: plan` with `mode: observe`.
+- Database grant targets must include `object.name`, matching the connected database.
+- Review declared memberships in external roles: they now take effect.
+- Adopt-mode schema-owner transfers require a separate explicit opt-in.
+- Validate policy size limits and UTC whole-second `password_valid_until` values.
+- Update JSON consumers for tagged default-privilege `scope`. Bundle output is
+  `pgroles.bundle_plan.v2`; ordinary diff JSON remains unversioned, so pin its
+  producer version.
+
+Version 0.10.1 changes each controller's default reconciliation concurrency to
+one. Keep that default until measurements support a higher value; see
+[running the operator](/docs/operator-operations#reconcile-concurrency).
+
+## Verify after upgrading
+
+For each policy, inspect conditions, observed generation, current plan, and
+warnings. For apply-mode convergence, require the observed generation to match,
+`Ready=True` with reason `Reconciled`, and `Drifted=False`; no plan should remain
+Pending, Approved, or Applying. An Applied plan may remain referenced.
+
+Observe mode and manual approval can legitimately have pending changes. Review
+replacement plans before approving, then test allowed and denied operations as
+actual service identities. Check operator restarts and inspection latency.
+
+If the upgrade fails, inspect [troubleshooting](/docs/operator-troubleshooting)
+before retrying. Reverting the chart alone neither downgrades CRDs nor undoes SQL.

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -52,7 +52,7 @@ spec:
 
   grants:
     - role: myapp-readonly
-      object: { type: database }
+      object: { type: database, name: app }
       privileges: [CONNECT]
 ```
 

--- a/docs/src/pages/docs/quick-start.md
+++ b/docs/src/pages/docs/quick-start.md
@@ -10,17 +10,11 @@ Get up and running with pgroles in a few minutes. {% .lead %}
 ## Prerequisites
 
 - **PostgreSQL 16, 17, or 18** — the versions supported and tested in CI
-- **Rust toolchain** (for building from source)
+- A disposable database named `mydb`, with a table in `public` and an administrator connection for this exercise
 
 ## Installation
 
-Build from source using Cargo:
-
-```shell
-cargo install --git https://github.com/thepartly/pgroles pgroles-cli
-```
-
-This installs the `pgroles` binary.
+Download the binary for your platform from the [latest stable release](https://github.com/thepartly/pgroles/releases/latest), then verify `pgroles --version`. See [installation](/docs/installation) for containers and Cargo.
 
 {% callout type="note" title="Starting from an existing database?" %}
 Use `pgroles generate --database-url ... > pgroles.yaml` first, then refine the generated flat manifest into profiles and schema bindings.
@@ -75,7 +69,7 @@ Manifest is valid.
 See what SQL would be generated against a live database:
 
 ```shell
-pgroles diff --database-url postgres://localhost/mydb
+pgroles diff --mode additive --database-url postgres://localhost/mydb
 ```
 
 This shows the exact SQL statements needed to converge the database to match your manifest.
@@ -89,13 +83,13 @@ The `diff` command (also available as `plan`) is read-only. It connects to your 
 When you're happy with the plan, apply it:
 
 ```shell
-pgroles apply --database-url postgres://localhost/mydb
+pgroles apply --mode additive --database-url postgres://localhost/mydb
 ```
 
 Or preview without executing:
 
 ```shell
-pgroles apply --database-url postgres://localhost/mydb --dry-run
+pgroles apply --mode additive --database-url postgres://localhost/mydb --dry-run
 ```
 
 ## Using environment variables
@@ -104,6 +98,10 @@ Instead of passing `--database-url` every time, set the `DATABASE_URL` environme
 
 ```shell
 export DATABASE_URL=postgres://localhost/mydb
-pgroles diff
-pgroles apply
+pgroles diff --mode additive
+pgroles apply --mode additive
 ```
+
+## Verify the result
+
+Run the same additive diff again; it should print `-- No changes needed`. This proves convergence within additive mode, which leaves undeclared access untouched. Continue with [staged adoption](/docs/adoption) before enabling revocations on an existing database.

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -12,7 +12,7 @@ One YAML file. Every role, grant, and privilege in your database — defined, di
 
 Managing PostgreSQL roles and privileges across environments is error-prone. Teams typically resort to ad-hoc SQL scripts, manual `GRANT` statements, or fragile migration files. When a new schema is added or a role needs adjusting, it's easy to miss a grant or leave stale privileges in place.
 
-pgroles takes a **convergent, declarative approach**: you define the desired state in a YAML manifest, and pgroles computes the exact SQL needed to bring your database in line. Anything in the database but not in the manifest gets revoked or dropped — so your access control never drifts.
+pgroles takes a **convergent, declarative approach**: you define the desired state in a YAML manifest, and pgroles computes the exact SQL needed to bring your database in line. pgroles reconciles the access your policy manages; the reconciliation mode determines what it may remove. Start with additive mode on an existing database, then review an adopt-mode plan when you are ready to remove undeclared access.
 
 Built for platform teams, DBAs, and anyone managing more than a handful of PostgreSQL roles across environments.
 
@@ -20,7 +20,7 @@ Built for platform teams, DBAs, and anyone managing more than a handful of Postg
 
 - **Write privilege rules once**, expand them across every schema automatically via profiles
 - **See exactly what will change** before touching the database with `pgroles diff`
-- **Convergent diff engine** — the manifest is the entire truth; stale grants get revoked
+- **Convergent diff engine** — remove undeclared access within the managed scope when your reconciliation mode permits it
 - **Dry-run mode** to preview generated SQL without executing
 - **Default privilege management** so future tables get the right grants automatically
 - **Role membership management** with inherit and admin flags

--- a/scripts/e2e-acl-inspection-burst.sh
+++ b/scripts/e2e-acl-inspection-burst.sh
@@ -27,7 +27,7 @@ schema_count="${BURST_SCHEMAS:-10}"
 function_count="${BURST_FUNCTIONS:-100}"
 role_count="${BURST_ROLES:-40}"
 # The bounded run must stay under this share of the unbounded run's peak.
-# Generous on purpose: the defaults give unbounded 2.5x the concurrency of
+# Generous on purpose: the defaults give unbounded 10x the concurrency of
 # bounded, so a real bound clears this comfortably and only its removal, which
 # makes the two runs identical, cannot.
 max_bounded_share_percent="${BURST_MAX_BOUNDED_SHARE_PERCENT:-80}"

--- a/scripts/e2e-doc-quick-start.sh
+++ b/scripts/e2e-doc-quick-start.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run the complete policy example from the operator quick start against the
+# disposable setup-e2e cluster. Do not maintain a second copy of the manifest.
+set -euo pipefail
+policy_file="$(mktemp)"
+cleanup() {
+  kubectl delete pgr quick-start -n pgroles-quick-start --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl delete namespace pgroles-quick-start --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl exec postgres-0 -- psql -U postgres -d docs_quickstart -c 'DROP OWNED BY pgroles_quickstart_reader' >/dev/null 2>&1 || true
+  kubectl exec postgres-0 -- psql -U postgres -d postgres -c 'DROP DATABASE IF EXISTS docs_quickstart' >/dev/null 2>&1 || true
+  kubectl exec postgres-0 -- psql -U postgres -d postgres -c 'DROP ROLE IF EXISTS pgroles_quickstart_reader' >/dev/null 2>&1 || true
+  rm -f "$policy_file"
+}
+trap cleanup EXIT
+python3 - "$policy_file" <<'PY'
+import re, sys
+from pathlib import Path
+page = Path('docs/src/pages/docs/operator-quick-start.md').read_text()
+blocks = [b for b in re.findall(r'```yaml\n(.*?)\n```', page, re.S) if 'kind: PostgresPolicy\n' in b]
+assert len(blocks) == 1, 'expected one complete quick-start policy'
+assert 'object: { type: database, name: app }' in blocks[0]
+Path(sys.argv[1]).write_text(blocks[0].replace('name: app }', 'name: docs_quickstart }'))
+PY
+kubectl exec postgres-0 -- psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE docs_quickstart'
+kubectl create namespace pgroles-quick-start
+kubectl create secret generic quick-start-database -n pgroles-quick-start \
+  --from-literal=DATABASE_URL=postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/docs_quickstart
+kubectl apply -f "$policy_file"
+kubectl wait -n pgroles-quick-start --for=condition=Ready pgr/quick-start --timeout=120s
+plan="$(kubectl get pgr quick-start -n pgroles-quick-start -o jsonpath='{.status.current_plan_ref.name}')"
+test -n "$plan"
+phase="$(kubectl get pgplan "$plan" -n pgroles-quick-start -o jsonpath='{.status.phase}')"
+test "$phase" = Pending
+sql="$(kubectl get pgplan "$plan" -n pgroles-quick-start -o jsonpath='{.status.sqlInline}')"
+[[ "$sql" == *'CREATE ROLE'* && "$sql" == *'GRANT CONNECT'* ]]
+[[ "$sql" != *REVOKE* && "$sql" != *'DROP '* ]]
+kubectl patch pgplan "$plan" -n pgroles-quick-start --subresource=status --type=merge -p \
+  "{\"status\":{\"conditions\":[{\"type\":\"Approved\",\"status\":\"True\",\"reason\":\"DocsSmokeTest\",\"lastTransitionTime\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}],\"decidedBy\":{\"username\":\"$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}')\"}}}"
+kubectl wait -n pgroles-quick-start --for=jsonpath='{.status.phase}'=Applied "pgplan/$plan" --timeout=120s
+kubectl wait -n pgroles-quick-start --for=condition=Drifted=false pgr/quick-start --timeout=120s
+result="$(kubectl exec postgres-0 -- psql -U postgres -d docs_quickstart -At -c "SELECT has_database_privilege('pgroles_quickstart_reader','docs_quickstart','CONNECT')")"
+test "$result" = t

--- a/skills/pgroles-operator/SKILL.md
+++ b/skills/pgroles-operator/SKILL.md
@@ -204,7 +204,7 @@ spec:
         login: false
     grants:
       - role: reporting_reader
-        object: { type: database }
+        object: { type: database, name: app }
         privileges: [CONNECT]
 ```
 

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -130,10 +130,9 @@ privileges there once any grant materializes the ACL — so plans never revoke
 them, declared grants on an owner's own objects converge as no-ops, and
 `generate` never exports them.
 
-PostgreSQL materializes an object's whole ACL, owner entry included, the first
-time anything is granted or revoked on it. Any first-time grant does this, and
-so does revoking `EXECUTE` from PUBLIC. Expect one extra convergence pass on
-such objects, and declare the owner privileges that must survive it.
+PostgreSQL materializes an object's ACL on the first grant or revoke, including
+a revoke of implicit PUBLIC access. Inspection protects owner entries, so
+materialization alone should not require an extra owner-repair pass.
 
 Ownership rights such as altering or dropping an object, and the owner's
 implicit grant options, remain PostgreSQL behavior outside the object ACL model.
@@ -170,6 +169,11 @@ Review effective and transitive privileges, not role names alone.
 - PUBLIC is reconciled only where a rule names it. A privilege PUBLIC holds that
   no rule mentions is left alone in every mode, so deleting a `present` PUBLIC
   rule does not revoke anything — switch it to `ensure: absent` instead.
+
+Wildcard revocations preserve concrete grantor attribution. Review per-object
+changes and ensure the executor can act as every recorded grantor. Do not
+replace those statements with a broad plain REVOKE. Versions through 0.10.1
+have a known wildcard grantor gap; use the matching release limitations.
 
 ## Safe Removal
 


### PR DESCRIPTION
Wildcard normalization could hide concrete ACL grantors, leaving delegated access behind after a successful revoke. Revokes now preserve concrete object/grantor identity, protect owners, and retain named exceptions beside wildcard rules. Live tests cover multiple grantors, PUBLIC, non-superuser authority, mixed ownership, and empty replans. Fixes #215.

ACL derivation and normalization now run under one process-wide blocking-work permit, sharing raw snapshots with Arc and leaving database waits outside the permit. Added phase/cardinality/runtime-lag telemetry, removed unnecessary ACL sorting and the intermediate row-pointer vector, and expanded the low-CPU burst gate to one and two Tokio workers. The serial reconcile default stays unchanged. Addresses #214; the cluster burst gate must pass before calling the operational validation complete.

The docs commit repairs database targets in onboarding examples, adds semantic example validation and a cluster quick-start smoke test, clarifies scoped adoption, and adds a version-matched upgrade guide.

Validation:
- Workspace unit/property tests and strict all-target/all-feature clippy passed during development.
- Grantor, PUBLIC, and shared-snapshot live tests passed on PostgreSQL 16 and 17; grantor live tests also passed on PostgreSQL 18. A full PG18 run is in progress against an isolated test database.
- Docs lint, all interactive labs, and production build passed; CRD/Helm drift and skill checks were run separately.
- Local 40,040-row profiling: one-worker maximum timer lag 197.863 ms inline versus 14.568 ms bounded; process peak RSS approximately 104 MB in both cases. Timer lag is not HTTP probe latency. Reproduction and the slower, rejected function-query experiment are recorded under correctness/performance/.

No digest fast path or concurrency-default increase is included. The burst job retains its explicit 512Mi test memory limit; it does not certify this fixture under the chart's default 128Mi limit.

Final exact-head validation: ordinary CI passed on 94e1cb02239ce9cc69c0fdc95ee78b8ceb8c6159, as did fairness/load and both ACL burst worker configurations (run 33926081262). The bounded default converged all ten policies with zero restarts: 76,382,208 bytes peak working set with one worker and 76,492,800 with two workers. Unbounded reconciliation did not complete in either run, so no bounded/unbounded ratio is claimed. These cluster runs used a 512 MiB memory limit; they do not establish a 128 MiB production guarantee.
