### PR TITLE
Measure and gate actual probe latency during bounded ACL bursts

### DIFF
--- a/correctness/performance/acl-inspection.md
+++ b/correctness/performance/acl-inspection.md
@@ -74,3 +74,9 @@ maximum resident set size (`/usr/bin/time -l`) was 103,792,640 bytes inline and
 103,235,584 bytes bounded. This is process RSS, not an allocation/heap profile;
 it supports no extra full snapshot copy, not a general memory reduction claim.
 Timing varies with host load. Use the low-CPU cluster gate for deployment claims.
+
+## Cluster validation
+
+Run [33926081262](https://github.com/thepartly/pgroles/actions/runs/33926081262) tested the chart's 200m CPU setting with one and two Tokio workers, ten policies, and 40,000 ACL rows per policy. Serial reconciliation converged with zero restarts and peak working sets of 76,382,208 and 76,492,800 bytes respectively. The test used a 512 MiB memory limit. Unbounded reconciliation failed to complete, so these runs do not provide a bounded/unbounded ratio or a 128 MiB production guarantee.
+
+The burst gate additionally samples real `/livez` and `/readyz` requests to the new pod through the Kubernetes API proxy. It reports p95 and maximum latency, includes proxy overhead, requires at least three samples per endpoint, and rejects failures or requests at or above the shipped two-second timeout after each endpoint first responds. Startup before the endpoint listens is excluded; pod restart checks remain independent. Tokio scheduling lag is a separate metric and is not presented as HTTP latency.

--- a/scripts/e2e-acl-inspection-burst.sh
+++ b/scripts/e2e-acl-inspection-burst.sh
@@ -35,6 +35,8 @@ max_bounded_share_percent="${BURST_MAX_BOUNDED_SHARE_PERCENT:-80}"
 namespace=pgroles-system
 deployment="deployment/pgroles-operator"
 sample_file="$(mktemp)"
+probe_file="$(mktemp)"
+probe_pid=""
 stop_file="$(mktemp)"
 rm -f "$stop_file"
 sampler_pid=""
@@ -44,7 +46,8 @@ cleanup() {
   if [ -n "$sampler_pid" ]; then
     wait "$sampler_pid" 2>/dev/null || true
   fi
-  rm -f "$sample_file" "$stop_file"
+  if [ -n "$probe_pid" ]; then wait "$probe_pid" 2>/dev/null || true; fi
+  rm -f "$sample_file" "$stop_file" "$probe_file"
 }
 trap cleanup EXIT
 
@@ -100,6 +103,10 @@ stop_sampler() {
     wait "$sampler_pid" 2>/dev/null || true
     sampler_pid=""
   fi
+  if [ -n "$probe_pid" ]; then
+    wait "$probe_pid"
+    probe_pid=""
+  fi
 }
 
 run_phase() {
@@ -121,6 +128,9 @@ run_phase() {
     done
   ) &
   sampler_pid="$!"
+  python3 "$(dirname "$0")/sample-operator-probes.py" --namespace "$namespace" \
+    --exclude-uid "$old_pod_uid" --output "$probe_file" --stop "$stop_file" &
+  probe_pid="$!"
 
   # `set env` changes the pod template in both phases (absent -> 0 -> absent),
   # so it is itself the one rollout under measurement. Starting the sampler and
@@ -207,6 +217,11 @@ done
 unbounded_completed=1
 run_phase 'unbounded (RECONCILE_CONCURRENCY=0)' RECONCILE_CONCURRENCY=0 || unbounded_completed=0
 unbounded_peak="$measured_peak"
+# The shipped liveness/readiness timeout is two seconds. This measures actual
+# HTTP requests via the API proxy, rather than treating zero restarts as a
+# latency measurement. Proxy overhead makes this a conservative bound.
+python3 "$(dirname "$0")/sample-operator-probes.py" --check --output "$probe_file" \
+  | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
 kubectl -n "$namespace" get pods -o wide || true
 if [ "$unbounded_completed" -eq 0 ]; then
   echo "the unbounded phase did not complete; the bounded phase is the whole assertion"

--- a/scripts/e2e-acl-inspection-burst.sh
+++ b/scripts/e2e-acl-inspection-burst.sh
@@ -217,11 +217,6 @@ done
 unbounded_completed=1
 run_phase 'unbounded (RECONCILE_CONCURRENCY=0)' RECONCILE_CONCURRENCY=0 || unbounded_completed=0
 unbounded_peak="$measured_peak"
-# The shipped liveness/readiness timeout is two seconds. This measures actual
-# HTTP requests via the API proxy, rather than treating zero restarts as a
-# latency measurement. Proxy overhead makes this a conservative bound.
-python3 "$(dirname "$0")/sample-operator-probes.py" --check --output "$probe_file" \
-  | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
 kubectl -n "$namespace" get pods -o wide || true
 if [ "$unbounded_completed" -eq 0 ]; then
   echo "the unbounded phase did not complete; the bounded phase is the whole assertion"
@@ -229,6 +224,11 @@ fi
 
 run_phase 'bounded (default)' RECONCILE_CONCURRENCY-
 bounded_peak="$measured_peak"
+# The shipped liveness/readiness timeout is two seconds. This measures actual
+# HTTP requests via the API proxy, rather than treating zero restarts as a
+# latency measurement. Proxy overhead makes this a conservative bound.
+python3 "$(dirname "$0")/sample-operator-probes.py" --check --output "$probe_file" \
+  | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 printf 'ACL inspection burst: %s policies x %s schemas x %s functions x %s roles (%s ACL rows each). Peak working set after restart: unbounded %s MiB, bounded %s MiB.\n' \
   "$policy_count" "$schema_count" "$function_count" "$role_count" \

--- a/scripts/sample-operator-probes.py
+++ b/scripts/sample-operator-probes.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Sample real pod health requests during a rollout; includes API proxy overhead."""
+import argparse
+import json
+import math
+from pathlib import Path
+import subprocess
+import time
+
+
+def run(command, timeout=5):
+    return subprocess.run(command, capture_output=True, timeout=timeout, check=False)
+
+
+def sample(namespace, excluded_uid, output, stop):
+    with output.open('w', buffering=1) as stream:
+        while not stop.exists():
+            try:
+                result = run(['kubectl', '-n', namespace, 'get', 'pods', '-l',
+                              'app.kubernetes.io/name=pgroles-operator', '-o', 'json'])
+                pods = json.loads(result.stdout).get('items', [])
+                for pod in pods:
+                    metadata = pod['metadata']
+                    if (metadata['uid'] == excluded_uid or metadata.get('deletionTimestamp')
+                            or pod.get('status', {}).get('phase') != 'Running'):
+                        continue
+                    for endpoint in ['livez', 'readyz']:
+                        started = time.monotonic()
+                        try:
+                            response = run(['kubectl', '--request-timeout=2s', 'get', '--raw',
+                                            f"/api/v1/namespaces/{namespace}/pods/{metadata['name']}:8080/proxy/{endpoint}"], timeout=3)
+                            ok = response.returncode == 0
+                        except subprocess.TimeoutExpired:
+                            ok = False
+                        stream.write(json.dumps({'uid': metadata['uid'], 'endpoint': endpoint,
+                                                 'ok': ok, 'ms': (time.monotonic() - started) * 1000}) + '\n')
+            except (subprocess.TimeoutExpired, ValueError, KeyError):
+                # Pod discovery is not an HTTP health sample. The checker
+                # requires samples for both endpoints, so an unavailable API
+                # cannot turn an unobserved run into a pass.
+                pass
+            time.sleep(1)
+
+
+def check(path, max_ms):
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    if len({row['uid'] for row in rows}) != 1:
+        raise SystemExit('expected probes from exactly one new pod')
+    for endpoint in ['livez', 'readyz']:
+        samples = [row for row in rows if row['endpoint'] == endpoint]
+        # Exclude startup before the endpoint first begins listening. Every
+        # subsequent failure counts, even if readiness later becomes false.
+        first = next((i for i, row in enumerate(samples) if row['ok']), len(samples))
+        samples = samples[first:]
+        if len(samples) < 3:
+            raise SystemExit(f'{endpoint}: fewer than three post-startup samples')
+        durations = sorted(row['ms'] for row in samples)
+        failures = sum(not row['ok'] for row in samples)
+        p95 = durations[math.ceil(len(durations) * .95) - 1]
+        print(f'{endpoint}: samples={len(samples)} failures={failures} p95={p95:.1f}ms max={durations[-1]:.1f}ms (includes API proxy overhead)')
+        if failures or durations[-1] >= max_ms:
+            raise SystemExit(f'{endpoint}: exceeded the {max_ms:g}ms probe budget')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--namespace', default='pgroles-system')
+    parser.add_argument('--exclude-uid')
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--stop', type=Path)
+    parser.add_argument('--check', action='store_true')
+    parser.add_argument('--max-ms', type=float, default=2000)
+    args = parser.parse_args()
+    if args.check:
+        check(args.output, args.max_ms)
+    elif args.stop is None or args.exclude_uid is None:
+        parser.error('sampling requires --stop and --exclude-uid')
+    else:
+        sample(args.namespace, args.exclude_uid, args.output, args.stop)


### PR DESCRIPTION
The ACL burst previously checked convergence and restart counts without quantifying HTTP probe latency. It now samples `/livez` and `/readyz` on the new pod during each rollout, reports p95/max latency, and gates the bounded phase against the shipped two-second probe timeout.

The measurement includes Kubernetes API proxy overhead. Startup before each endpoint first responds is excluded; every subsequent failed request counts. Both endpoints require at least three samples, and mixed-pod or missing coverage fails. Restart and memory checks remain independent. The performance note records the completed one-/two-worker measurements from #217 without claiming an unobserved unbounded-memory ratio.

Validation: shell syntax, Python compilation, checker cases covering healthy/missing/slow/failed/mixed-pod samples, and strict workspace Clippy passed. Exact-head CI and [live burst run 33930592308](https://github.com/thepartly/pgroles/actions/runs/33930592308) passed on `d13597c`. Both worker configurations converged all 10 policies with zero restarts and zero failed post-startup probes.

| Tokio workers | Peak working set | livez p95 / max | readyz p95 / max |
| --- | --- | --- | --- |
| 1 | 76,050,432 bytes | 315.2 / 389.9 ms | 139.0 / 154.0 ms |
| 2 | 76,378,112 bytes | 136.4 / 158.2 ms | 195.7 / 337.2 ms |

The fixture used 200m CPU and a 512 MiB memory limit, with 40,000 ACL rows per policy. The unbounded phases did not complete, so no memory ratio is claimed.

Closes #214.
