### PR TITLE
Stop appending generated GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,21 +92,19 @@ jobs:
             exit 1
           fi
 
-          # Lead the body with this version's changelog entry, the way releases
-          # read before the process moved into this workflow. GitHub appends its
-          # generated "What's Changed" list after it.
+          # Use only this version's curated changelog entry. Do not add
+          # --generate-notes: GitHub would append a duplicate change list.
           awk -v section="## [${tag#v}]" '
             index($0, section) == 1 { inside = 1; next }
             inside && /^## \[/ { exit }
             inside { print }
           ' CHANGELOG.md > release-notes.md
 
-          release_args=(--verify-tag --title "$tag" --generate-notes --draft)
-          if [ -s release-notes.md ]; then
-            release_args+=(--notes-file release-notes.md)
-          else
-            echo "::warning::No CHANGELOG.md section found for ${tag}; using generated notes only."
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::Missing or empty CHANGELOG.md section for ${tag}; refusing to create a release without curated notes."
+            exit 1
           fi
+          release_args=(--verify-tag --title "$tag" --notes-file release-notes.md --draft)
           if [[ "$tag" == *-* ]]; then
             release_args+=(--prerelease)
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,10 @@ The tag push then drives everything, in this order:
    runs before anything else, so tagging a commit CI has not passed costs
    nothing.
 2. **`prepare-github-release`** creates a *draft* release, with the body taken
-   from that version's `CHANGELOG.md` section and GitHub's generated "What's
-   Changed" appended. Every publishing job waits on it, so a release that was
-   published by hand fails here — while nothing has reached crates.io or GHCR.
+   only from that version's `CHANGELOG.md` section. Never pass `--generate-notes`:
+   it appends a duplicate GitHub change list. A missing or empty changelog entry
+   stops the release. Every publishing job waits on this gate, so a release that
+   was published by hand fails here — while nothing has reached crates.io or GHCR.
 3. **`build-binaries`** cross-compiles the CLI for four targets.
 4. **`docker-operator`** and **`docker-cli`** push, sign, and attest the images.
 5. **`publish-crates`** publishes the four crates, after the images rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release notes use only the matching changelog entry, without GitHub's duplicated change list. Missing or empty release notes stop draft creation.
+
 ## [0.11.0] - 2026-09-06
 
 ### Upgrade notes


### PR DESCRIPTION
Release creation passed both `--notes-file` and `--generate-notes`, causing GitHub to append a second change list after the curated changelog. Use only the matching changelog section and fail draft creation when that section is missing or empty. Update contributor instructions to preserve this behavior.

The published v0.11.0 body has separately been corrected to match its tagged changelog; its four assets are unchanged.

Validation: exercised the actual workflow shell with a mocked GitHub CLI for matching, missing, whitespace-only, and prerelease sections; verified exact notes and creation arguments. Bash syntax, formatting, workspace Clippy, and diff checks passed.
