### PR TITLE
Correct pgroles skills and docs against PostgreSQL 18 semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,12 @@ diff(current, effective desired) → Vec<Change> → sql::render_all_with_contex
 - **pgroles-operator** — Kubernetes operator. Reconciles `PostgresPolicy` CRDs (`pgroles.io/v1alpha1`). Has a `crdgen` binary for generating the CRD YAML.
   - Kubernetes identifiers: every name and label value derived from user input goes through `k8s_names`. Do not hand-roll truncation or character filtering elsewhere — a cut that lands on a separator yields a value the API server rejects, which surfaces as a policy that silently stops reconciling. Invariants are enforced by property tests in `tests/identifier_properties.rs`.
   - Health endpoints: `/livez`, `/readyz`
-  - Reconciliation modes: `apply`, `plan`
+  - Execution modes: `apply`, `observe` (`plan` is a deprecated spelling of `observe`; omitted approval defaults to manual for either)
   - Metrics/telemetry: prefer OTLP export via OpenTelemetry Collector; do not add a built-in Prometheus scrape endpoint by default unless the change explicitly requires it.
 
 ### Diff Change Ordering
 
-`diff()` assembles changes in dependency order: creates → alters/comments → grants → default privileges → membership removes → membership adds → default privilege revocations → revocations → drops. Retirement steps (terminate sessions, reassign owned, drop owned) are inserted immediately before the matching `DropRole` by `apply_role_retirements()`. `apply` executes the whole plan in a single transaction.
+`diff()` assembles changes in dependency order: creates → alters/comments → grants → default privileges → object revocations → membership removes → membership adds → default privilege revocations → drops. Retirement steps (terminate sessions, reassign owned, drop owned) are inserted immediately before the matching `DropRole` by `apply_role_retirements()`. `apply` executes the whole plan in a single transaction.
 
 ## CI
 

--- a/docs/src/pages/docs/executor-privileges.md
+++ b/docs/src/pages/docs/executor-privileges.md
@@ -9,7 +9,7 @@ pgroles does not require superuser. It needs `CREATEROLE` plus a handful of scop
 
 ## What pgroles actually needs
 
-The table targets PostgreSQL 16. `CREATEROLE` permits ordinary role creation;
+The table targets PostgreSQL 16–18. `CREATEROLE` permits ordinary role creation;
 existing-role administration and object operations need separate authority.
 Protected roles and managed-provider restrictions can impose additional limits.
 
@@ -29,9 +29,9 @@ Protected roles and managed-provider restrictions can impose additional limits.
 | `terminate_sessions` (retirements) | membership in `pg_signal_backend` (cannot terminate superuser sessions) |
 | inspection (`diff`/`plan`/`generate`) | none beyond `CONNECT` — `pg_roles`, `pg_shdescription`, and ACL columns are readable by any role |
 
-See PostgreSQL's [CREATE SCHEMA](https://www.postgresql.org/docs/16/sql-createschema.html),
-[ALTER SCHEMA](https://www.postgresql.org/docs/16/sql-alterschema.html), and
-[GRANT](https://www.postgresql.org/docs/16/sql-grant.html) references for these distinctions.
+See PostgreSQL's [CREATE SCHEMA](https://www.postgresql.org/docs/18/sql-createschema.html),
+[ALTER SCHEMA](https://www.postgresql.org/docs/18/sql-alterschema.html), and
+[GRANT](https://www.postgresql.org/docs/18/sql-grant.html) references for these distinctions.
 
 ## Greenfield and brownfield prerequisites
 
@@ -42,14 +42,19 @@ PostgreSQL 16 changed `CREATEROLE` semantics: a role with `CREATEROLE` automatic
 - ability to `SET ROLE` to any other role assigned as a schema owner
 - inherited privileges of each default-privilege creator role (which need not be the schema owner)
 
-Automatic `ADMIN OPTION` does not itself provide `INHERIT` or `SET` access. A
-non-superuser cannot create a new owner role and run `ALTER DEFAULT PRIVILEGES
-FOR ROLE owner` in the same pgroles transaction. For owner-bound defaults,
-pre-create the owner and grant the executor membership, bootstrap in two stages,
-or use a superuser for the atomic first apply. Creating a schema owned by a new
-role likewise needs a usable `SET ROLE` path before the schema statement.
-Declaring a membership in the same manifest is insufficient: pgroles adds
-memberships after schema changes and default-privilege grants.
+Automatic `ADMIN OPTION` does not itself provide `INHERIT` or `SET` access.
+PostgreSQL's [createrole_self_grant](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-CREATEROLE-SELF-GRANT)
+can give a non-superuser immediate inheritance or SET access to roles it creates.
+However, pgroles v0.11.0 preflight does not account for that setting: it rejects
+plans that create a default-privilege owner and alter its defaults as a
+non-superuser. This is a pgroles limitation, not a PostgreSQL prohibition.
+
+For owner-bound defaults, pre-create the owner and grant the executor the
+required access, bootstrap in two stages, or use a superuser for the atomic
+first apply. Creating a schema owned by another role likewise needs a usable
+`SET ROLE` path before the schema statement. Declaring a membership in the same
+manifest cannot supply these earlier prerequisites: pgroles adds memberships
+after schema changes and default-privilege grants.
 
 The friction also shows up in **brownfield** adoption. `CREATEROLE` does not retroactively grant `ADMIN OPTION` on roles that already existed before the executor was created. For every pre-existing role pgroles needs to alter, drop, or manage memberships on, a superuser or existing admin must explicitly grant the executor admin rights:
 

--- a/docs/src/pages/docs/executor-privileges.md
+++ b/docs/src/pages/docs/executor-privileges.md
@@ -9,7 +9,9 @@ pgroles does not require superuser. It needs `CREATEROLE` plus a handful of scop
 
 ## What pgroles actually needs
 
-This table was verified against a live PostgreSQL 16 server. `CREATEROLE` is the load-bearing attribute; everything else is either automatic (for roles the executor created itself) or a narrow, explicit grant.
+The table targets PostgreSQL 16. `CREATEROLE` permits ordinary role creation;
+existing-role administration and object operations need separate authority.
+Protected roles and managed-provider restrictions can impose additional limits.
 
 | pgroles operation | Requires |
 |---|---|
@@ -18,28 +20,36 @@ This table was verified against a live PostgreSQL 16 server. `CREATEROLE` is the
 | `GRANT`/`REVOKE` role memberships | `ADMIN OPTION` on the granted (group) role — automatic for roles the executor created. On PostgreSQL 16+ pgroles revokes each edge `GRANTED BY` its recorded grantor, which additionally requires the privileges of that grantor (membership with inheritance; superusers qualify everywhere) — the plan preflight reports any grantor the executor lacks |
 | `GRANT`/`REVOKE` predefined (`pg_*`) role memberships | `ADMIN OPTION` on the predefined role — never automatic: a superuser must run `GRANT pg_read_all_data TO executor WITH ADMIN OPTION` (or the executor must be superuser). The plan preflight warns and apply blocks when this is missing |
 | `DROP ROLE` | `CREATEROLE` + `ADMIN OPTION` on the role |
-| `CREATE SCHEMA` | `CREATE` privilege on the database |
-| `ALTER SCHEMA ... OWNER TO` | ownership of the schema plus membership in the new owner role |
-| `GRANT`/`REVOKE` on tables/sequences/functions | ownership of the objects, directly or via membership in the owning role. Revokes run as the recorded grantor of each ACL entry (`SET ROLE`), which requires membership in that grantor with the `SET` option (superusers qualify everywhere) — the plan preflight reports any grantor the executor cannot become |
-| `ALTER DEFAULT PRIVILEGES FOR ROLE x` | membership (privileges) of role `x` — `ADMIN OPTION` alone is **not** enough |
+| `CREATE SCHEMA` | `CREATE` on the database; assigning another owner also requires the ability to `SET ROLE` to that owner |
+| `ALTER SCHEMA ... OWNER TO` | ownership of the schema, ability to `SET ROLE` to the new owner, and `CREATE` on the database for the new owner |
+| `GRANT`/`REVOKE` on tables/sequences/functions | grant authority on every affected object: ownership or the relevant privilege with grant option. Grantor-attributed revokes run as the recorded grantor of each ACL entry (`SET ROLE`), which requires membership in that grantor with the `SET` option (superusers qualify everywhere) — the plan preflight reports any grantor the executor cannot become |
+| `ALTER DEFAULT PRIVILEGES FOR ROLE x` | effective privileges of role `x` (self or an inheriting membership path) — `ADMIN OPTION` or the ability to `SET ROLE` alone is **not** enough for pgroles' emitted statement |
 | `REASSIGN OWNED BY a TO b` (retirements) | membership (privileges) of **both** `a` and `b`. The executor has `ADMIN OPTION` on roles it created, so it can `GRANT a TO executor` itself first — pgroles does not do this automatically |
 | `DROP OWNED BY a` (retirements) | membership (privileges) of `a` |
 | `terminate_sessions` (retirements) | membership in `pg_signal_backend` (cannot terminate superuser sessions) |
 | inspection (`diff`/`plan`/`generate`) | none beyond `CONNECT` — `pg_roles`, `pg_shdescription`, and ACL columns are readable by any role |
 
-## Why greenfield is nearly free and brownfield has friction
+See PostgreSQL's [CREATE SCHEMA](https://www.postgresql.org/docs/16/sql-createschema.html),
+[ALTER SCHEMA](https://www.postgresql.org/docs/16/sql-alterschema.html), and
+[GRANT](https://www.postgresql.org/docs/16/sql-grant.html) references for these distinctions.
+
+## Greenfield and brownfield prerequisites
 
 PostgreSQL 16 changed `CREATEROLE` semantics: a role with `CREATEROLE` automatically receives `ADMIN OPTION` on any role it creates. That collapses most of the table above into a single attribute for a **greenfield** executor — one that creates every role it will later alter, grant, or drop. A fresh executor needs only:
 
 - `CREATEROLE`
 - `CREATE` on the target database (to create schemas)
-- membership in the schema-owner role(s) it manages default privileges for
+- ability to `SET ROLE` to any other role assigned as a schema owner
+- inherited privileges of each default-privilege creator role (which need not be the schema owner)
 
-There is one greenfield exception: `ADMIN OPTION` is not membership. A
+Automatic `ADMIN OPTION` does not itself provide `INHERIT` or `SET` access. A
 non-superuser cannot create a new owner role and run `ALTER DEFAULT PRIVILEGES
 FOR ROLE owner` in the same pgroles transaction. For owner-bound defaults,
 pre-create the owner and grant the executor membership, bootstrap in two stages,
-or use a superuser for the atomic first apply.
+or use a superuser for the atomic first apply. Creating a schema owned by a new
+role likewise needs a usable `SET ROLE` path before the schema statement.
+Declaring a membership in the same manifest is insufficient: pgroles adds
+memberships after schema changes and default-privilege grants.
 
 The friction also shows up in **brownfield** adoption. `CREATEROLE` does not retroactively grant `ADMIN OPTION` on roles that already existed before the executor was created. For every pre-existing role pgroles needs to alter, drop, or manage memberships on, a superuser or existing admin must explicitly grant the executor admin rights:
 
@@ -62,19 +72,21 @@ CREATE ROLE pgroles_executor WITH LOGIN PASSWORD '...' CREATEROLE;
 -- 2. Let it create schemas in the target database.
 GRANT CREATE ON DATABASE mydb TO pgroles_executor;
 
--- 3. If pgroles will manage default privileges owned by an existing
---    schema-owner role, give the executor membership in that role.
-GRANT app_owner TO pgroles_executor;
+-- 3. For an existing role used as both schema owner and default-privilege
+--    creator, give the executor the required inheritance and SET paths.
+GRANT app_owner TO pgroles_executor WITH INHERIT TRUE, SET TRUE;
 
 -- 4. Brownfield only: for each pre-existing role pgroles must alter,
 --    drop, or manage memberships on, grant explicit admin rights.
 GRANT some_preexisting_role TO pgroles_executor WITH ADMIN TRUE;
 ```
 
-Steps 1–2 cover a greenfield executor only when the first plan does not alter
-defaults for an owner it also creates. Step 3 is required for every existing
-default-privilege owner. For an owner created by the policy, use the two-stage
-or superuser bootstrap described above. Step 4 is brownfield-only.
+Steps 1–2 suffice only when the plan needs no additional owner authority.
+Step 3 gives the executor an inheritance path to the owner for default
+privileges and a SET path for schema assignment; grant only the options
+the plan needs. Repeat for each relevant owner. For owners created by the policy,
+use the staged bootstrap above. Step 4 covers pre-existing roles requiring
+administration.
 
 ## Cloud providers
 

--- a/docs/src/pages/docs/limitations.md
+++ b/docs/src/pages/docs/limitations.md
@@ -11,6 +11,14 @@ What pgroles does not cover, so you know where the edges of the declared-state m
 
 `GRANT SELECT (col) ON table` remains unmanaged by pgroles: column-level grants are not diffed, not revoked, and `pgroles generate` does not export them — manifests only describe table-level access. pgroles does, however, detect column-level grants during `diff` and `apply` — in schemas whose privileges it manages (schemas referenced by grants or default privileges in the manifest): if any are found, it prints a warning (schema, table, grantee, affected columns, and privileges) so the gap is visible instead of silent. The warning does not block `diff`/`apply` and the grants themselves are still not managed — you must review and, if needed, revoke them manually.
 
+## MAINTAIN privilege
+
+PostgreSQL 17 introduced the table-level `MAINTAIN` privilege; it is also
+available in PostgreSQL 18. pgroles v0.11.0 cannot declare or reconcile it, and
+its ACL inspection omits it. A clean diff therefore does not verify maintenance
+access. Review it directly in PostgreSQL. See the
+[PostgreSQL 17 release notes](https://www.postgresql.org/docs/17/release-17.html).
+
 ## Membership SET option
 
 On PostgreSQL 15 and older there is no per-membership `INHERIT` option at all: inheritance is governed solely by the member role's `INHERIT` attribute, which pgroles already manages as a role attribute. Inspection on those versions reports the member's attribute as the edge's `inherit` value, so a membership whose member role sets `inherit: false` diffs against the edge default of `true` and plans a revoke-and-regrant that cannot change anything — the plan re-appears on every run. On pre-16 servers, leave the per-member `inherit` field unset and manage inheritance through the role's own `inherit` attribute.
@@ -38,7 +46,11 @@ warns and `apply` blocks. It checks authority against the plan's execution order
 so removing a membership cannot silently invalidate a later statement's authority.
 
 Wildcard revocations expand to concrete changes because different objects may
-have different owners and grantors. Owner-inherent privileges are preserved.
+have different owners and grantors. pgroles preserves existing owner-grantee
+ACL entries. This is a reconciliation choice: PostgreSQL allows an owner to
+revoke ordinary privileges from itself, while ownership rights and implicit
+grant options remain inherent. Missing declared owner privileges can still be
+granted. See [PostgreSQL privileges](https://www.postgresql.org/docs/18/ddl-priv.html).
 The plan can therefore contain more entries than the wildcard rules in the
 manifest; review its complete SQL. This behavior is available since
 v0.11.0. In 0.10.0–0.10.1, wildcard-collapsed revokes can fall back to a plain revoke

--- a/docs/src/pages/docs/operator-candidates.md
+++ b/docs/src/pages/docs/operator-candidates.md
@@ -1,6 +1,6 @@
 ---
 title: Candidates and promotion
-description: Propose policy changes, review their exact PostgreSQL effects, and promote them — while the active policy keeps enforcing during review.
+description: Preview proposed policy effects and promote reviewed content while the active policy keeps enforcing.
 ---
 
 For field types, defaults, and admission constraints, see the [CRD API reference](/docs/operator-api-reference).
@@ -27,8 +27,8 @@ A `PostgresPolicyCandidate` is a one-shot, immutable proposal: policy content
 that an author wants reviewed against a live database without touching the
 `PostgresPolicy` that is enforcing it. The operator plans the candidate in the
 active policy's own execution context — same credentials, same advisory lock,
-same managed scope — and publishes a `PostgresPolicyPlan` describing exactly
-what would change. The active policy keeps enforcing throughout review. (After
+same managed scope — and publishes a `PostgresPolicyPlan` of proposed effects
+with the [preview limitations](#preview-limitations) below. The active policy keeps enforcing throughout review. (After
 promotion the picture changes if the promotion does not match its approval —
 see [Promotion](#promotion).)
 
@@ -43,6 +43,23 @@ The kinds divide authority. Anyone granted create on candidates can propose;
 only whoever can write `PostgresPolicy` (typically your GitOps controller) can
 promote; only plan approvers can approve. None of those grants implies the
 others.
+
+## Preview limitations
+
+In v0.11.0, candidate planning does not run every enforcing-policy check:
+
+- It omits the `preserve_undeclared_grants` filter, so it can preview object
+  revokes that the parent would suppress after promotion.
+- It omits executor-authority preflight, plan advisory warnings, and the adopt
+  mode schema-owner-transfer guard. `Ready=True` means a preview is available;
+  it does not prove the executor can apply it. Execution settings such as
+  `allow_schema_owner_transfers` remain on the parent, outside candidate content.
+
+Promotion recomputes effects and checks the approved digest before execution.
+Different effects require a replacement plan; matching effects can still be
+blocked by executor privileges or execution settings. Review those prerequisites
+separately using [Executor privileges](/docs/executor-privileges), and verify
+Applied and parent convergence after promotion.
 
 ## Who does what
 
@@ -87,8 +104,8 @@ spec:
 ```
 
 `spec.content` is the exact policy-content schema from `PostgresPolicySpec` —
-everything except connection, interval, mode, and approval. Interval, mode and
-approval always come from the parent policy; the connection does too, unless
+excluding execution settings: connection, interval, mode, suspend, approval,
+and allow_schema_owner_transfers. Those settings come from the parent policy; the connection does too, unless
 `spec.target` overrides it (see [Previewing a connection
 migration](#previewing-a-connection-migration)). The whole spec is immutable
 (`self == oldSelf`); to revise a proposal, create a successor:
@@ -202,8 +219,8 @@ that made it, whether it is still current or has been superseded, the applied
 base it is pinned to, and any promotion outcome. A candidate with no plan yet
 reports that, with the reason, rather than printing a blank plan section.
 
-`diff` prints the reviewed plan's SQL on stdout: what approving this candidate
-would execute. It reads `status.sqlInline`, falling back to the gzipped
+`diff` prints the proposed plan's SQL on stdout. Approval alone executes nothing;
+promotion requires a fresh matching digest and successful execution checks. It reads `status.sqlInline`, falling back to the gzipped
 ConfigMap in `status.sqlRef` when the plan is too large to inline. A plan
 whose SQL survives only as a truncated preview is an error, not a short diff,
 because a partial listing could be read as the full set of statements the

--- a/docs/src/pages/docs/profiles.md
+++ b/docs/src/pages/docs/profiles.md
@@ -89,7 +89,7 @@ Each `schema x profile` combination produces:
 2. **Grants** from the profile, scoped to the schema
 3. **Default privileges** from the profile, scoped to the schema
 
-The example above generates four roles: `inventory-editor`, `inventory-viewer`, `catalog-viewer`, plus all their associated grants and default privileges.
+The example above generates three roles: `inventory-editor`, `inventory-viewer`, `catalog-viewer`, plus all their associated grants and default privileges.
 
 ## Custom role naming
 

--- a/docs/src/pages/docs/tooling.md
+++ b/docs/src/pages/docs/tooling.md
@@ -72,9 +72,10 @@ Some PostgreSQL-backed libraries and platform features create their own tables, 
 
 Do not point pgroles at an internally managed schema and expect it to understand that system's upgrade invariants. pgroles manages privileges around those objects; the schema-owning system still owns its DDL.
 
-Since v0.11.0, pgroles preserves owner-inherent ACL entries on tables,
+Since v0.11.0, pgroles preserves existing owner-grantee ACL entries on tables,
 sequences, functions, and types; declaring those grants is not needed to prevent
-revocation. Schema ownership also ensures effective `CREATE` and `USAGE` on the
+pgroles revoking them. PostgreSQL itself permits owners to revoke their ordinary
+privileges, and pgroles can grant missing declared privileges back. Schema ownership also ensures effective `CREATE` and `USAGE` on the
 schema. Owning a schema does not imply ownership of its contents: declare grants
 or memberships for access to objects owned by another role, and default
 privileges for each role that creates future objects.

--- a/docs/src/pages/docs/tooling.md
+++ b/docs/src/pages/docs/tooling.md
@@ -72,7 +72,12 @@ Some PostgreSQL-backed libraries and platform features create their own tables, 
 
 Do not point pgroles at an internally managed schema and expect it to understand that system's upgrade invariants. pgroles manages privileges around those objects; the schema-owning system still owns its DDL.
 
-If the owner role is also managed by pgroles in `authoritative` mode, declare the privileges that role should keep on its own schema. PostgreSQL owners effectively have broad access to their objects, and pgroles treats undeclared visible privileges as drift.
+Since v0.11.0, pgroles preserves owner-inherent ACL entries on tables,
+sequences, functions, and types; declaring those grants is not needed to prevent
+revocation. Schema ownership also ensures effective `CREATE` and `USAGE` on the
+schema. Owning a schema does not imply ownership of its contents: declare grants
+or memberships for access to objects owned by another role, and default
+privileges for each role that creates future objects.
 
 ## Bundles for teams
 

--- a/skills/pgroles-operator/SKILL.md
+++ b/skills/pgroles-operator/SKILL.md
@@ -225,6 +225,12 @@ Interpretation:
 - `Ready=False, reason=BlockedByActivePolicy` means the parent is failing or
   has its own plan awaiting a decision; the candidate is planned once the
   parent settles.
+- In v0.11.0, candidate planning omits the `preserve_undeclared_grants`
+  filter, executor-authority preflight, advisory warnings, and adopt-mode
+  schema-owner-transfer guard. It can preview revokes the parent suppresses;
+  `Ready=True` does not prove apply will succeed. Check executor authority and
+  parent execution settings separately. Changed effects require a replacement
+  plan at promotion; the approved digest does not bypass execution checks.
 - The spec is immutable. Revise by filing a successor that names this
   candidate in `spec.replaces`.
 - Approving the candidate's plan executes nothing by itself. Execution happens

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -207,7 +207,12 @@ Before completing a change:
 2. render bundles before reviewing their effective policy
 3. inspect `pgroles graph` and the complete SQL diff
 4. confirm external roles and referenced undeclared schemas already exist
-5. verify the executor has ownership, grant options, and role administration
+5. verify executor authority for each SQL phase: `ADMIN` manages role
+   memberships, `INHERIT` makes owner privileges available, and `SET` permits
+   switching roles. Default-privilege grants precede membership additions, so a
+   membership declared in the same plan cannot bootstrap those grants. Schema
+   assignment needs a usable SET path; transferring an existing schema also
+   requires database `CREATE` for its new owner
 6. apply first in a non-production environment when possible
 7. run positive and negative SQL checks as the actual login roles
 8. run a second diff and require no changes within the selected mode

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -105,6 +105,13 @@ anyone else.
 The external role must already exist whenever retained SQL references it. Ensure
 the provider or IaC rollout completes before pgroles apply.
 
+## Membership SET Option
+
+In v0.11.0, pgroles manages membership `inherit` and `admin`, but not `SET`.
+Changing those options can revoke and recreate an edge with PostgreSQL's
+default `SET TRUE`. Do not use `SET FALSE` as a security boundary on a
+pgroles-managed membership; a clean diff does not verify its SET option.
+
 ## Predefined (pg_*) Roles
 
 PostgreSQL's predefined roles (`pg_read_all_data`, `pg_monitor`, ...) may be
@@ -138,11 +145,11 @@ transfer schema ownership away from the live owner unless apply passes
 Schema ownership is modeled specially: pgroles converges the declared owner and
 ensures that owner has effective `CREATE` and `USAGE` on the schema.
 
-Table, sequence, function, and type ownership is not modeled. Inspection tags
-owner-grantee ACL entries as inherent — PostgreSQL records the owner's
-privileges there once any grant materializes the ACL — so plans never revoke
-them, declared grants on an owner's own objects converge as no-ops, and
-`generate` never exports them.
+Table, sequence, function, and type ownership is not modeled. pgroles preserves
+existing owner-grantee ACL entries and omits them from `generate`. This is a
+pgroles reconciliation choice: PostgreSQL permits owners to revoke their own
+ordinary privileges. Declared owner grants produce no SQL when already held;
+missing declared privileges can still be granted.
 
 PostgreSQL materializes an object's ACL on the first grant or revoke, including
 a revoke of implicit PUBLIC access. Inspection protects owner entries, so
@@ -180,6 +187,9 @@ Review effective and transitive privileges, not role names alone.
   than the new membership suggests.
 - Column-level grants are outside desired-state reconciliation. Read inspection
   warnings and review them separately.
+- v0.11.0 does not model `MAINTAIN` (introduced in PostgreSQL 17). Inspection
+  omits it and manifests cannot declare it; verify maintenance access separately
+  even when the diff is clean.
 - PUBLIC is reconciled only where a rule names it. A privilege PUBLIC holds that
   no rule mentions is left alone in every mode, so deleting a `present` PUBLIC
   rule does not revoke anything — switch it to `ensure: absent` instead.


### PR DESCRIPTION
Correct skills and documentation where v0.11.0 guidance overstates candidate execution guarantees or conflates PostgreSQL privileges with pgroles reconciliation behavior. Reviewed against implementation and PostgreSQL 18 documentation, retaining PostgreSQL 16–18 distinctions.

- Document candidate preview gaps: preserved-grant filtering, authority preflight, advisory warnings, and the adopt ownership-transfer guard. Promotion still checks fresh effects against approval.
- Clarify ADMIN, INHERIT, and SET authority, schema ownership prerequisites, and SQL phase ordering. Attribute the non-superuser default-owner bootstrap restriction to pgroles preflight; PostgreSQL's createrole_self_grant can provide immediate authority, but v0.11.0 preflight does not account for it.
- Distinguish pgroles preserving existing owner ACL entries from PostgreSQL allowing owners to revoke ordinary privileges. Missing declared owner privileges can still be granted.
- Warn that pgroles does not manage membership SET options and can recreate edges with SET TRUE. Document the unmodeled PostgreSQL 17+ MAINTAIN privilege.
- Correct profile role counts and repository agent guidance on modes and phase ordering.

Validation: both skills pass the pinned skills-ref validator; cargo fmt, Clippy with all targets/features and warnings denied, and git diff --check pass. Previously validated 31 YAML examples with released v0.11.0 (profile fragments combined with their page's definitions); those examples are unchanged by the PostgreSQL 18 review corrections. An independent review checked PostgreSQL 18 docs and source, including retirement authority. No live PostgreSQL/Kubernetes tests or full documentation build. Runtime limitations are documented, not fixed in this PR.
