### PR TITLE
Fix default-owner bootstrap authority preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Authority preflight recognizes PostgreSQL 16+ `createrole_self_grant=inherit` when a non-superuser creates a default-privilege owner in the same plan. Later default revokes account for planned roles, automatic inherited memberships, and membership removals, additions, and inheritance downgrades.
 - Release notes use only the matching changelog entry, without GitHub's duplicated change list. Missing or empty release notes stop draft creation.
 
 ## [0.11.0] - 2026-09-06

--- a/crates/pgroles-inspect/src/preflight.rs
+++ b/crates/pgroles-inspect/src/preflight.rs
@@ -988,6 +988,8 @@ struct GrantorAuthorityRow {
 /// executor never had. Planned roles and automatic creation grants are
 /// included before membership removals and additions. Removals and inheritance
 /// downgrades conservatively remove every grantor edge for the named pair.
+/// Additions count only with existing ADMIN authority, or the automatic ADMIN
+/// grant a CREATEROLE executor receives for a role it creates.
 /// Superusers are never passed here.
 async fn roles_unreachable_in_graph(
     pool: &PgPool,
@@ -1035,6 +1037,12 @@ async fn roles_unreachable_in_graph(
             SELECT a.rolname, a.memname FROM added a
             JOIN known g ON g.rolname = a.rolname
             JOIN known mem ON mem.rolname = a.memname
+            LEFT JOIN pg_roles live_role ON live_role.rolname = a.rolname
+            WHERE CASE WHEN live_role.oid IS NULL THEN
+                a.rolname = ANY($6)
+                AND (SELECT rolcreaterole FROM pg_roles WHERE rolname = current_user)
+            ELSE pg_has_role(current_user, live_role.oid, 'MEMBER WITH ADMIN OPTION')
+            END
         ),
         reach(rolname) AS (
             SELECT current_user::text

--- a/crates/pgroles-inspect/src/preflight.rs
+++ b/crates/pgroles-inspect/src/preflight.rs
@@ -334,6 +334,41 @@ pub async fn preflight_authority_issues(
             .await?;
     let server_major = (server_version_num / 10_000) as u32;
 
+    let created: Vec<String> = changes
+        .iter()
+        .filter_map(|change| match change {
+            Change::CreateRole { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    // PostgreSQL 16+ can grant inherited authority immediately at CREATE ROLE.
+    // SET alone is insufficient: default-privilege SQL does not SET ROLE.
+    let inherits_created = if server_major >= 16
+        && executor_has_createrole
+        && !executor_is_superuser
+        && !created.is_empty()
+    {
+        let setting: String = sqlx::query_scalar("SHOW createrole_self_grant")
+            .fetch_one(pool)
+            .await?;
+        setting.split(',').any(|option| {
+            option
+                .trim()
+                .trim_matches('"')
+                .eq_ignore_ascii_case("inherit")
+        })
+    } else {
+        false
+    };
+    let creation_edges: Vec<(String, String)> = if inherits_created {
+        created
+            .iter()
+            .map(|role| (role.clone(), executor.clone()))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     // --- Predefined-role membership authority ---
     // Granting or revoking membership in a predefined (`pg_*`) role requires
     // ADMIN OPTION on it. `pg_has_role(..., 'MEMBER WITH ADMIN OPTION')`
@@ -515,9 +550,7 @@ pub async fn preflight_authority_issues(
             _ => None,
         })
         .collect();
-    // Only inheriting additions extend USAGE. An added edge referencing a
-    // role the plan also creates cannot resolve against pg_roles yet and is
-    // conservatively ignored.
+    // Only inheriting additions extend USAGE.
     let added_edges: Vec<(String, String)> = changes
         .iter()
         .filter_map(|change| match change {
@@ -530,9 +563,25 @@ pub async fn preflight_authority_issues(
             _ => None,
         })
         .collect();
+    // GRANT ... INHERIT FALSE can overwrite an automatic creation grant,
+    // even without a preceding RemoveMember (the role did not exist at
+    // inspection). Apply these downgrades only after the addition phase.
+    let defaults_removed_edges: Vec<(String, String)> = removed_edges
+        .iter()
+        .cloned()
+        .chain(changes.iter().filter_map(|change| match change {
+            Change::AddMember {
+                role,
+                member,
+                inherit: false,
+                ..
+            } => Some((role.clone(), member.clone())),
+            _ => None,
+        }))
+        .collect();
     // Owners of `SetDefaultPrivilege` changes, which execute before any
-    // membership change: the current-state owner check below judges them, so
-    // the phase check must not also report an owner that carries both kinds.
+    // membership change: the owner check below judges their initial authority.
+    // The later phase check avoids duplicating that check's failures.
     let set_owners: BTreeSet<String> = changes
         .iter()
         .filter_map(|change| match change {
@@ -545,7 +594,7 @@ pub async fn preflight_authority_issues(
     // current graph — is authoritative for RevokeDefaultPrivilege owners, so
     // the current-state owner check below must not double-judge them.
     let revoke_owners_phase_checked =
-        phase_checks_active && !(removed_edges.is_empty() && added_edges.is_empty());
+        phase_checks_active && !(defaults_removed_edges.is_empty() && added_edges.is_empty());
     if phase_checks_active {
         let mut broken_by_plan: BTreeSet<String> = BTreeSet::new();
         let mut never_usable: BTreeSet<String> = BTreeSet::new();
@@ -554,9 +603,15 @@ pub async fn preflight_authority_issues(
         // any addition, so only removals can affect them.
         if !removed_edges.is_empty() && !membership_grantors.is_empty() {
             let membership_phase_roles: Vec<String> = membership_grantors.iter().cloned().collect();
-            for (grantor, usable_now) in
-                roles_unreachable_in_graph(pool, &membership_phase_roles, &removed_edges, &[])
-                    .await?
+            for (grantor, usable_now) in roles_unreachable_in_graph(
+                pool,
+                &membership_phase_roles,
+                &removed_edges,
+                &[],
+                &created,
+                &creation_edges,
+            )
+            .await?
             {
                 // A grantor the executor cannot use even now was already
                 // flagged exactly (ForeignGrantorMembershipRevoke) above.
@@ -583,8 +638,10 @@ pub async fn preflight_authority_issues(
             for (owner, usable_now) in roles_unreachable_in_graph(
                 pool,
                 &defaults_phase_roles,
-                &removed_edges,
+                &defaults_removed_edges,
                 &added_edges,
+                &created,
+                &creation_edges,
             )
             .await?
             {
@@ -603,9 +660,10 @@ pub async fn preflight_authority_issues(
             });
         }
         for owner in never_usable {
-            // An owner that also carries a SetDefaultPrivilege change gets
-            // the identical issue from the current-state check below.
-            if set_owners.contains(&owner) {
+            // Avoid duplicating a failing grant-phase check. A new owner
+            // with inherited creation authority passes that check, but can
+            // still lose authority before its later revoke.
+            if set_owners.contains(&owner) && !(inherits_created && created.contains(&owner)) {
                 continue;
             }
             issues.push(AuthorityIssue::DefaultPrivilegeOwner {
@@ -651,28 +709,22 @@ pub async fn preflight_authority_issues(
                 });
             }
         }
-        // A non-superuser cannot act as a role merely because the same plan
-        // creates it. PostgreSQL's automatic CREATEROLE administration grant
-        // does not provide the USAGE authority ALTER DEFAULT PRIVILEGES
-        // requires. Reject before the transaction starts; superusers can
-        // safely create the owner and alter its defaults atomically.
-        let created: BTreeSet<&str> = changes
-            .iter()
-            .filter_map(|change| match change {
-                Change::CreateRole { name, .. } => Some(name.as_str()),
-                _ => None,
-            })
-            .collect();
+        // Creation precedes default grants; later revokes use the phase graph
+        // when memberships change, including CREATE ROLE's automatic edges.
         for owner in &owners {
             if known.contains(owner) {
                 continue;
             }
-            if created.contains(owner.as_str()) && !executor_is_superuser {
+            if created.contains(owner)
+                && !executor_is_superuser
+                && !inherits_created
+                && (set_owners.contains(owner) || !revoke_owners_phase_checked)
+            {
                 issues.push(AuthorityIssue::DefaultPrivilegeOwner {
                     owner: owner.clone(),
                     executor: executor.clone(),
                 });
-            } else if !created.contains(owner.as_str()) {
+            } else if !created.contains(owner) {
                 issues.push(AuthorityIssue::MissingDefaultPrivilegeOwner {
                     owner: owner.clone(),
                 });
@@ -933,14 +985,17 @@ struct GrantorAuthorityRow {
 /// phase equivalent of `pg_has_role(current_user, role, 'USAGE')`. Each
 /// unreachable role is returned with whether the executor can use it *now*,
 /// so callers can distinguish authority the plan breaks from authority the
-/// executor never had. Additions resolve against `pg_roles`, so an edge
-/// referencing a role the plan also creates is conservatively ignored.
+/// executor never had. Planned roles and automatic creation grants are
+/// included before membership removals and additions. Removals and inheritance
+/// downgrades conservatively remove every grantor edge for the named pair.
 /// Superusers are never passed here.
 async fn roles_unreachable_in_graph(
     pool: &PgPool,
     roles: &[String],
     removed: &[(String, String)],
     added: &[(String, String)],
+    created: &[String],
+    creation_edges: &[(String, String)],
 ) -> Result<Vec<(String, bool)>, sqlx::Error> {
     if roles.is_empty() {
         return Ok(Vec::new());
@@ -948,6 +1003,8 @@ async fn roles_unreachable_in_graph(
     let (removed_roles, removed_members): (Vec<String>, Vec<String>) =
         removed.iter().cloned().unzip();
     let (added_roles, added_members): (Vec<String>, Vec<String>) = added.iter().cloned().unzip();
+    let (creation_roles, creation_members): (Vec<String>, Vec<String>) =
+        creation_edges.iter().cloned().unzip();
     let rows: Vec<(String, bool)> = sqlx::query_as(
         r#"
         WITH RECURSIVE removed(rolname, memname) AS (
@@ -956,31 +1013,40 @@ async fn roles_unreachable_in_graph(
         added(rolname, memname) AS (
             SELECT * FROM unnest($4::text[], $5::text[])
         ),
-        edges(roleid, member) AS (
-            SELECT m.roleid, m.member
+        known(rolname) AS (
+            SELECT rolname::text FROM pg_roles
+            UNION SELECT unnest($6::text[])
+        ),
+        initial_edges(rolname, memname) AS (
+            SELECT g.rolname::text, mem.rolname::text
             FROM pg_auth_members m
             JOIN pg_roles g ON g.oid = m.roleid
             JOIN pg_roles mem ON mem.oid = m.member
             WHERE m.inherit_option
-              AND NOT EXISTS (
-                  SELECT 1 FROM removed d
-                  WHERE d.rolname = g.rolname AND d.memname = mem.rolname
-              )
-            UNION
-            SELECT g.oid, mem.oid
-            FROM added a
-            JOIN pg_roles g ON g.rolname = a.rolname
-            JOIN pg_roles mem ON mem.rolname = a.memname
+            UNION SELECT * FROM unnest($7::text[], $8::text[])
         ),
-        reach(oid) AS (
-            SELECT oid FROM pg_roles WHERE rolname = current_user
+        edges(rolname, memname) AS (
+            SELECT e.rolname, e.memname FROM initial_edges e
+            WHERE NOT EXISTS (
+                SELECT 1 FROM removed d
+                WHERE d.rolname = e.rolname AND d.memname = e.memname
+            )
             UNION
-            SELECT e.roleid FROM edges e JOIN reach r ON e.member = r.oid
+            SELECT a.rolname, a.memname FROM added a
+            JOIN known g ON g.rolname = a.rolname
+            JOIN known mem ON mem.rolname = a.memname
+        ),
+        reach(rolname) AS (
+            SELECT current_user::text
+            UNION
+            SELECT e.rolname FROM edges e JOIN reach r ON e.memname = r.rolname
         )
-        SELECT r.rolname::text, pg_has_role(current_user, r.oid, 'USAGE')
-        FROM pg_roles r
-        WHERE r.rolname = ANY($1)
-          AND r.oid NOT IN (SELECT oid FROM reach)
+        SELECT k.rolname,
+               CASE WHEN r.oid IS NULL THEN false
+                    ELSE pg_has_role(current_user, r.oid, 'USAGE') END
+        FROM known k LEFT JOIN pg_roles r ON r.rolname = k.rolname
+        WHERE k.rolname = ANY($1)
+          AND k.rolname NOT IN (SELECT rolname FROM reach)
         "#,
     )
     .bind(roles)
@@ -988,6 +1054,9 @@ async fn roles_unreachable_in_graph(
     .bind(&removed_members)
     .bind(&added_roles)
     .bind(&added_members)
+    .bind(created)
+    .bind(&creation_roles)
+    .bind(&creation_members)
     .fetch_all(pool)
     .await?;
     Ok(rows)

--- a/crates/pgroles-inspect/src/preflight.rs
+++ b/crates/pgroles-inspect/src/preflight.rs
@@ -610,6 +610,7 @@ pub async fn preflight_authority_issues(
                 &[],
                 &created,
                 &creation_edges,
+                &removed_edges,
             )
             .await?
             {
@@ -642,6 +643,7 @@ pub async fn preflight_authority_issues(
                 &added_edges,
                 &created,
                 &creation_edges,
+                &removed_edges,
             )
             .await?
             {
@@ -988,8 +990,10 @@ struct GrantorAuthorityRow {
 /// executor never had. Planned roles and automatic creation grants are
 /// included before membership removals and additions. Removals and inheritance
 /// downgrades conservatively remove every grantor edge for the named pair.
-/// Additions count only with existing ADMIN authority, or the automatic ADMIN
-/// grant a CREATEROLE executor receives for a role it creates.
+/// Additions require a surviving ADMIN grant held by the executor or a role
+/// it inherits after removals/downgrades, or automatic ADMIN on a new role.
+/// Conservatively, additions cannot establish their own grant prerequisites;
+/// newly acquired administrator paths are not used to authorize other additions.
 /// Superusers are never passed here.
 async fn roles_unreachable_in_graph(
     pool: &PgPool,
@@ -998,6 +1002,7 @@ async fn roles_unreachable_in_graph(
     added: &[(String, String)],
     created: &[String],
     creation_edges: &[(String, String)],
+    admin_removed: &[(String, String)],
 ) -> Result<Vec<(String, bool)>, sqlx::Error> {
     if roles.is_empty() {
         return Ok(Vec::new());
@@ -1005,12 +1010,17 @@ async fn roles_unreachable_in_graph(
     let (removed_roles, removed_members): (Vec<String>, Vec<String>) =
         removed.iter().cloned().unzip();
     let (added_roles, added_members): (Vec<String>, Vec<String>) = added.iter().cloned().unzip();
+    let (admin_removed_roles, admin_removed_members): (Vec<String>, Vec<String>) =
+        admin_removed.iter().cloned().unzip();
     let (creation_roles, creation_members): (Vec<String>, Vec<String>) =
         creation_edges.iter().cloned().unzip();
     let rows: Vec<(String, bool)> = sqlx::query_as(
         r#"
         WITH RECURSIVE removed(rolname, memname) AS (
             SELECT * FROM unnest($2::text[], $3::text[])
+        ),
+        admin_removed(rolname, memname) AS (
+            SELECT * FROM unnest($9::text[], $10::text[])
         ),
         added(rolname, memname) AS (
             SELECT * FROM unnest($4::text[], $5::text[])
@@ -1027,12 +1037,33 @@ async fn roles_unreachable_in_graph(
             WHERE m.inherit_option
             UNION SELECT * FROM unnest($7::text[], $8::text[])
         ),
-        edges(rolname, memname) AS (
+        surviving_edges(rolname, memname) AS (
             SELECT e.rolname, e.memname FROM initial_edges e
             WHERE NOT EXISTS (
                 SELECT 1 FROM removed d
                 WHERE d.rolname = e.rolname AND d.memname = e.memname
             )
+        ),
+        grantor_reach(rolname) AS (
+            SELECT current_user::text
+            UNION
+            SELECT e.rolname FROM surviving_edges e
+            JOIN grantor_reach r ON e.memname = r.rolname
+        ),
+        usable_admin(rolname) AS (
+            SELECT g.rolname::text
+            FROM pg_auth_members m
+            JOIN pg_roles g ON g.oid = m.roleid
+            JOIN pg_roles mem ON mem.oid = m.member
+            JOIN grantor_reach r ON r.rolname = mem.rolname
+            WHERE m.admin_option
+              AND NOT EXISTS (
+                  SELECT 1 FROM admin_removed d
+                  WHERE d.rolname = g.rolname AND d.memname = mem.rolname
+              )
+        ),
+        edges(rolname, memname) AS (
+            SELECT * FROM surviving_edges
             UNION
             SELECT a.rolname, a.memname FROM added a
             JOIN known g ON g.rolname = a.rolname
@@ -1041,7 +1072,8 @@ async fn roles_unreachable_in_graph(
             WHERE CASE WHEN live_role.oid IS NULL THEN
                 a.rolname = ANY($6)
                 AND (SELECT rolcreaterole FROM pg_roles WHERE rolname = current_user)
-            ELSE pg_has_role(current_user, live_role.oid, 'MEMBER WITH ADMIN OPTION')
+            ELSE a.rolname <> current_user
+                 AND a.rolname IN (SELECT rolname FROM usable_admin)
             END
         ),
         reach(rolname) AS (
@@ -1065,6 +1097,8 @@ async fn roles_unreachable_in_graph(
     .bind(created)
     .bind(&creation_roles)
     .bind(&creation_members)
+    .bind(&admin_removed_roles)
+    .bind(&admin_removed_members)
     .fetch_all(pool)
     .await?;
     Ok(rows)

--- a/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
+++ b/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
@@ -248,6 +248,66 @@ async fn default_owner_bootstrap_matches_postgres() {
             }
         }
     }
+    // A new bridge provides inherited access only if the preceding membership
+    // GRANT is executable. CREATEROLE does not confer ADMIN on existing owners.
+    for can_admin in [false, true] {
+        pool.execute("BEGIN; CREATE ROLE csg_executor CREATEROLE NOINHERIT; CREATE ROLE csg_owner")
+            .await
+            .unwrap();
+        if can_admin {
+            pool.execute("GRANT csg_owner TO csg_executor WITH ADMIN TRUE, INHERIT FALSE")
+                .await
+                .unwrap();
+        }
+        pool.execute("SET LOCAL ROLE csg_executor; SET LOCAL createrole_self_grant = 'inherit'")
+            .await
+            .unwrap();
+        let changes = vec![
+            Change::CreateRole {
+                name: "csg_bridge".into(),
+                state: RoleState::default(),
+            },
+            Change::AddMember {
+                role: "csg_owner".into(),
+                member: "csg_bridge".into(),
+                inherit: true,
+                admin: false,
+            },
+            Change::RevokeDefaultPrivilege {
+                owner: "csg_owner".into(),
+                scope: DefaultPrivilegeScope::Global,
+                on_type: ObjectType::Function,
+                grantee: Grantee::Public,
+                privileges: [Privilege::Execute].into(),
+            },
+        ];
+        let issues = preflight_authority_issues(&pool, &changes, &RoleGraph::default()).await;
+        let mut failure = None;
+        'plan: for change in &changes {
+            for statement in render_statements(change) {
+                if let Err(error) = pool.execute(statement.as_str()).await {
+                    failure = Some((statement, error));
+                    break 'plan;
+                }
+            }
+        }
+        pool.execute("ROLLBACK").await.unwrap();
+        assert_eq!(
+            issues.unwrap(),
+            if can_admin { vec![] } else { owner_issue() }
+        );
+        if can_admin {
+            assert!(failure.is_none(), "{failure:?}");
+        } else {
+            let (statement, error) = failure.expect("membership GRANT must fail");
+            assert!(statement.starts_with("GRANT "), "{statement}: {error}");
+            assert_eq!(
+                error.as_database_error().and_then(|e| e.code()).as_deref(),
+                Some("42501")
+            );
+        }
+    }
+
     // Superusers do not need self-grants, and a role always has authority over
     // its own defaults even when NOINHERIT and without CREATEROLE.
     for superuser in [false, true] {

--- a/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
+++ b/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
@@ -358,3 +358,170 @@ async fn default_owner_bootstrap_matches_postgres() {
     }
     pool.close().await;
 }
+
+/// ADMIN reachable through plain membership is insufficient for rendered GRANT:
+/// the executor must retain inherited access to a usable grantor at that phase.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to a superuser"]
+async fn planned_owner_grants_require_surviving_admin_authority() {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&std::env::var("DATABASE_URL").expect("DATABASE_URL"))
+        .await
+        .unwrap();
+    let version: i32 = sqlx::query_scalar("SELECT current_setting('server_version_num')::int")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    if version < 160_000 {
+        return;
+    }
+
+    for (case, inherits_admin, remove_admin, downgrade_admin, independent_admin) in [
+        ("noninherited admin", false, false, false, false),
+        ("retained inherited admin", true, false, false, false),
+        ("removed inherited admin", true, true, false, false),
+        (
+            "independent admin survives removal",
+            true,
+            true,
+            false,
+            true,
+        ),
+        ("downgraded inherited admin", true, false, true, false),
+        (
+            "independent admin survives downgrade",
+            true,
+            false,
+            true,
+            true,
+        ),
+    ] {
+        pool.execute(
+            "BEGIN;
+             CREATE ROLE csg_gap_owner;
+             CREATE ROLE csg_gap_executor CREATEROLE NOINHERIT;
+             SET LOCAL ROLE csg_gap_executor;
+             SET LOCAL createrole_self_grant = 'inherit';
+             CREATE ROLE csg_gap_admin",
+        )
+        .await
+        .unwrap();
+        if !inherits_admin {
+            pool.execute("GRANT csg_gap_admin TO csg_gap_executor WITH INHERIT FALSE")
+                .await
+                .unwrap();
+        }
+        pool.execute(
+            "RESET ROLE;
+             GRANT csg_gap_owner TO csg_gap_admin WITH ADMIN TRUE, INHERIT FALSE",
+        )
+        .await
+        .unwrap();
+        if independent_admin {
+            pool.execute("GRANT csg_gap_owner TO csg_gap_executor WITH ADMIN TRUE, INHERIT FALSE")
+                .await
+                .unwrap();
+        }
+        pool.execute("SET LOCAL ROLE csg_gap_executor")
+            .await
+            .unwrap();
+        // All setups pass the broad catalog predicate that previously
+        // admitted infeasible grants. The owner's privileges are not inherited.
+        let catalog_admin: bool = sqlx::query_scalar(
+            "SELECT pg_has_role(current_user, 'csg_gap_owner', 'MEMBER WITH ADMIN OPTION')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let mut changes = vec![Change::CreateRole {
+            name: "csg_gap_bridge".into(),
+            state: RoleState::default(),
+        }];
+        if remove_admin {
+            changes.push(Change::RemoveMember {
+                role: "csg_gap_admin".into(),
+                member: "csg_gap_executor".into(),
+                grantor: Some("csg_gap_executor".into()),
+            });
+        }
+        if downgrade_admin {
+            changes.push(Change::AddMember {
+                role: "csg_gap_admin".into(),
+                member: "csg_gap_executor".into(),
+                inherit: false,
+                admin: false,
+            });
+        }
+        if independent_admin {
+            // admin:false omits ADMIN in the renderer; it must not erase the
+            // existing independent ADMIN grant when preflight models this plan.
+            changes.push(Change::AddMember {
+                role: "csg_gap_owner".into(),
+                member: "csg_gap_executor".into(),
+                inherit: false,
+                admin: false,
+            });
+        }
+        changes.extend([
+            Change::AddMember {
+                role: "csg_gap_owner".into(),
+                member: "csg_gap_bridge".into(),
+                inherit: true,
+                admin: false,
+            },
+            Change::RevokeDefaultPrivilege {
+                owner: "csg_gap_owner".into(),
+                scope: DefaultPrivilegeScope::Global,
+                on_type: ObjectType::Function,
+                grantee: Grantee::Public,
+                privileges: [Privilege::Execute].into(),
+            },
+        ]);
+        let issues = preflight_authority_issues(&pool, &changes, &RoleGraph::default()).await;
+        let mut failure = None;
+        'plan: for change in &changes {
+            for statement in render_statements(change) {
+                if let Err(error) = pool.execute(statement.as_str()).await {
+                    failure = Some((statement, error));
+                    break 'plan;
+                }
+            }
+        }
+        pool.execute("ROLLBACK").await.unwrap();
+
+        assert!(catalog_admin, "setup: {case}");
+        let executable = independent_admin || (inherits_admin && !remove_admin && !downgrade_admin);
+        assert_eq!(
+            issues.unwrap(),
+            if executable {
+                vec![]
+            } else {
+                vec![AuthorityIssue::DefaultPrivilegeOwner {
+                    owner: "csg_gap_owner".into(),
+                    executor: "csg_gap_executor".into(),
+                }]
+            },
+            "preflight: {case}"
+        );
+        if executable {
+            assert!(failure.is_none(), "SQL: {case}: {failure:?}");
+        } else {
+            let (statement, error) = failure.expect("membership GRANT must fail");
+            assert!(
+                statement.starts_with("GRANT \"csg_gap_owner\""),
+                "{case}: {statement}: {error}"
+            );
+            // PostgreSQL versions differ in whether they reject the missing
+            // grantor as insufficient privilege or fail grantor selection.
+            assert!(
+                matches!(
+                    error.as_database_error().and_then(|e| e.code()).as_deref(),
+                    Some("42501" | "XX000")
+                ),
+                "{case}: {statement}: {error}"
+            );
+        }
+    }
+    pool.close().await;
+}

--- a/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
+++ b/crates/pgroles-inspect/tests/createrole_self_grant_live.rs
@@ -1,0 +1,300 @@
+//! Compare bootstrap preflight with actual SQL, rolling every case back.
+use pgroles_core::diff::Change;
+use pgroles_core::manifest::{ObjectType, Privilege};
+use pgroles_core::model::{DefaultPrivilegeScope, Grantee, RoleGraph, RoleState};
+use pgroles_core::sql::render_statements;
+use pgroles_inspect::{AuthorityIssue, preflight_authority_issues};
+use sqlx::{Executor, PgPool, postgres::PgPoolOptions};
+
+/// Always roll back before asserting, including when preflight or SQL fails.
+async fn check_plan(pool: &PgPool, changes: &[Change], expected: Vec<AuthorityIssue>, case: &str) {
+    let issues = preflight_authority_issues(pool, changes, &RoleGraph::default()).await;
+    let mut failure = None;
+    'plan: for change in changes {
+        for statement in render_statements(change) {
+            if let Err(error) = pool.execute(statement.as_str()).await {
+                failure = Some((statement, error));
+                break 'plan;
+            }
+        }
+    }
+    pool.execute("ROLLBACK").await.unwrap();
+    assert_eq!(issues.unwrap(), expected, "preflight: {case}");
+    if expected.is_empty() {
+        assert!(failure.is_none(), "SQL: {case}: {failure:?}");
+    } else {
+        let (statement, error) =
+            failure.unwrap_or_else(|| panic!("SQL unexpectedly passed: {case}"));
+        assert!(
+            statement.starts_with("ALTER DEFAULT PRIVILEGES"),
+            "{case}: {statement}: {error}"
+        );
+        let expected_code = if matches!(
+            expected[0],
+            AuthorityIssue::MissingDefaultPrivilegeOwner { .. }
+        ) {
+            "42704"
+        } else {
+            "42501"
+        };
+        assert_eq!(
+            error
+                .as_database_error()
+                .and_then(|error| error.code())
+                .as_deref(),
+            Some(expected_code),
+            "{case}: {statement}: {error}"
+        );
+    }
+}
+
+fn owner_issue() -> Vec<AuthorityIssue> {
+    vec![AuthorityIssue::DefaultPrivilegeOwner {
+        owner: "csg_owner".into(),
+        executor: "csg_executor".into(),
+    }]
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to a superuser"]
+async fn default_owner_bootstrap_matches_postgres() {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&std::env::var("DATABASE_URL").expect("DATABASE_URL"))
+        .await
+        .unwrap();
+    let version: i32 = sqlx::query_scalar("SELECT current_setting('server_version_num')::int")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    if version < 160_000 {
+        return;
+    }
+
+    for setting in ["", "set", "inherit", "set, inherit", "\"inherit\""] {
+        // Grant phase, revoke phase, authority removal, and restoration.
+        for phase in [
+            "grant",
+            "revoke",
+            "remove",
+            "restore",
+            "add",
+            "both_remove",
+            "both_restore",
+            "noninherit",
+            "both_noninherit",
+            "grant_then_noninherit",
+        ] {
+            pool.execute(
+                "BEGIN; CREATE ROLE csg_executor CREATEROLE NOINHERIT; SET LOCAL ROLE csg_executor",
+            )
+            .await
+            .unwrap();
+            sqlx::query("SELECT set_config('createrole_self_grant', $1, true)")
+                .bind(setting)
+                .execute(&pool)
+                .await
+                .unwrap();
+            let mut changes = vec![Change::CreateRole {
+                name: "csg_owner".into(),
+                state: RoleState::default(),
+            }];
+            if phase.starts_with("both_") || phase == "grant_then_noninherit" {
+                changes.push(Change::SetDefaultPrivilege {
+                    owner: "csg_owner".into(),
+                    scope: DefaultPrivilegeScope::Global,
+                    on_type: ObjectType::Table,
+                    grantee: Grantee::Public,
+                    privileges: [Privilege::Select].into(),
+                });
+            }
+            if matches!(phase, "remove" | "restore" | "both_remove" | "both_restore") {
+                changes.push(Change::RemoveMember {
+                    role: "csg_owner".into(),
+                    member: "csg_executor".into(),
+                    grantor: None,
+                });
+            }
+            if matches!(phase, "restore" | "add" | "both_restore") {
+                changes.push(Change::AddMember {
+                    role: "csg_owner".into(),
+                    member: "csg_executor".into(),
+                    inherit: true,
+                    admin: false,
+                });
+            }
+            if matches!(
+                phase,
+                "noninherit" | "both_noninherit" | "grant_then_noninherit"
+            ) {
+                changes.push(Change::AddMember {
+                    role: "csg_owner".into(),
+                    member: "csg_executor".into(),
+                    inherit: false,
+                    admin: false,
+                });
+            }
+            if phase != "grant_then_noninherit" {
+                changes.push(if phase == "grant" {
+                    Change::SetDefaultPrivilege {
+                        owner: "csg_owner".into(),
+                        scope: DefaultPrivilegeScope::Global,
+                        on_type: ObjectType::Table,
+                        grantee: Grantee::Public,
+                        privileges: [Privilege::Select].into(),
+                    }
+                } else {
+                    Change::RevokeDefaultPrivilege {
+                        owner: "csg_owner".into(),
+                        scope: DefaultPrivilegeScope::Global,
+                        on_type: ObjectType::Function,
+                        grantee: Grantee::Public,
+                        privileges: [Privilege::Execute].into(),
+                    }
+                });
+            }
+            let expected = matches!(phase, "restore" | "add")
+                || (setting.contains("inherit")
+                    && !matches!(
+                        phase,
+                        "remove" | "both_remove" | "noninherit" | "both_noninherit"
+                    ));
+            check_plan(
+                &pool,
+                &changes,
+                if expected { vec![] } else { owner_issue() },
+                &format!("{setting:?} {phase}"),
+            )
+            .await;
+        }
+    }
+
+    // The setting affects creation only: it cannot provide authority over an
+    // existing owner, and it cannot make an undeclared missing owner exist.
+    for owner_state in ["existing_usable", "existing_unusable", "missing", "created"] {
+        for revoke in [false, true] {
+            for scope in [
+                DefaultPrivilegeScope::Global,
+                DefaultPrivilegeScope::Schema {
+                    schema: "csg_schema".into(),
+                },
+            ] {
+                pool.execute("BEGIN; CREATE ROLE csg_executor CREATEROLE NOINHERIT; CREATE SCHEMA csg_schema AUTHORIZATION csg_executor").await.unwrap();
+                if owner_state.starts_with("existing_") {
+                    pool.execute("CREATE ROLE csg_owner").await.unwrap();
+                }
+                if owner_state == "existing_usable" {
+                    pool.execute("GRANT csg_owner TO csg_executor WITH INHERIT TRUE")
+                        .await
+                        .unwrap();
+                }
+                pool.execute(
+                    "SET LOCAL ROLE csg_executor; SET LOCAL createrole_self_grant = 'inherit'",
+                )
+                .await
+                .unwrap();
+                let mut changes = Vec::new();
+                if owner_state == "created" {
+                    changes.push(Change::CreateRole {
+                        name: "csg_owner".into(),
+                        state: RoleState::default(),
+                    });
+                }
+                // Exercise the phase graph for revokes too, without affecting
+                // authority over csg_owner.
+                if revoke {
+                    changes.push(Change::CreateRole {
+                        name: "csg_other".into(),
+                        state: RoleState::default(),
+                    });
+                    changes.push(Change::AddMember {
+                        role: "csg_other".into(),
+                        member: "csg_executor".into(),
+                        inherit: true,
+                        admin: false,
+                    });
+                }
+                changes.push(if revoke {
+                    Change::RevokeDefaultPrivilege {
+                        owner: "csg_owner".into(),
+                        scope: scope.clone(),
+                        on_type: ObjectType::Function,
+                        grantee: Grantee::Public,
+                        privileges: [Privilege::Execute].into(),
+                    }
+                } else {
+                    Change::SetDefaultPrivilege {
+                        owner: "csg_owner".into(),
+                        scope: scope.clone(),
+                        on_type: ObjectType::Table,
+                        grantee: Grantee::Public,
+                        privileges: [Privilege::Select].into(),
+                    }
+                });
+                let expected = match owner_state {
+                    "existing_unusable" => owner_issue(),
+                    "missing" => vec![AuthorityIssue::MissingDefaultPrivilegeOwner {
+                        owner: "csg_owner".into(),
+                    }],
+                    _ => vec![],
+                };
+                check_plan(
+                    &pool,
+                    &changes,
+                    expected,
+                    &format!("{owner_state} revoke={revoke} scope={scope:?}"),
+                )
+                .await;
+            }
+        }
+    }
+    // Superusers do not need self-grants, and a role always has authority over
+    // its own defaults even when NOINHERIT and without CREATEROLE.
+    for superuser in [false, true] {
+        for revoke in [false, true] {
+            pool.execute("BEGIN; SET LOCAL createrole_self_grant = ''")
+                .await
+                .unwrap();
+            let mut changes = Vec::new();
+            let owner = if superuser {
+                changes.push(Change::CreateRole {
+                    name: "csg_owner".into(),
+                    state: RoleState::default(),
+                });
+                "csg_owner"
+            } else {
+                pool.execute(
+                    "CREATE ROLE csg_executor NOINHERIT NOCREATEROLE; SET LOCAL ROLE csg_executor",
+                )
+                .await
+                .unwrap();
+                "csg_executor"
+            };
+            changes.push(if revoke {
+                Change::RevokeDefaultPrivilege {
+                    owner: owner.into(),
+                    scope: DefaultPrivilegeScope::Global,
+                    on_type: ObjectType::Function,
+                    grantee: Grantee::Public,
+                    privileges: [Privilege::Execute].into(),
+                }
+            } else {
+                Change::SetDefaultPrivilege {
+                    owner: owner.into(),
+                    scope: DefaultPrivilegeScope::Global,
+                    on_type: ObjectType::Table,
+                    grantee: Grantee::Public,
+                    privileges: [Privilege::Select].into(),
+                }
+            });
+            check_plan(
+                &pool,
+                &changes,
+                vec![],
+                &format!("superuser={superuser} revoke={revoke}"),
+            )
+            .await;
+        }
+    }
+    pool.close().await;
+}

--- a/docs/src/pages/docs/executor-privileges.md
+++ b/docs/src/pages/docs/executor-privileges.md
@@ -43,18 +43,37 @@ PostgreSQL 16 changed `CREATEROLE` semantics: a role with `CREATEROLE` automatic
 - inherited privileges of each default-privilege creator role (which need not be the schema owner)
 
 Automatic `ADMIN OPTION` does not itself provide `INHERIT` or `SET` access.
-PostgreSQL's [createrole_self_grant](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-CREATEROLE-SELF-GRANT)
-can give a non-superuser immediate inheritance or SET access to roles it creates.
-However, pgroles v0.11.0 preflight does not account for that setting: it rejects
-plans that create a default-privilege owner and alter its defaults as a
-non-superuser. This is a pgroles limitation, not a PostgreSQL prohibition.
+On PostgreSQL 16+, [createrole_self_grant](https://www.postgresql.org/docs/18/runtime-config-client.html#GUC-CREATEROLE-SELF-GRANT)
+can give a non-superuser immediate inherited authority over roles it creates.
+With `'inherit'` (or `'set, inherit'`), pgroles can create a default-privilege
+owner and grant its defaults in one apply. `'set'` alone is insufficient:
+pgroles does not switch roles when altering defaults. The setting affects
+newly created roles only.
 
-For owner-bound defaults, pre-create the owner and grant the executor the
-required access, bootstrap in two stages, or use a superuser for the atomic
-first apply. Creating a schema owned by another role likewise needs a usable
-`SET ROLE` path before the schema statement. Declaring a membership in the same
-manifest cannot supply these earlier prerequisites: pgroles adds memberships
-after schema changes and default-privilege grants.
+Configure the authenticated login role, then reconnect:
+
+```sql
+ALTER ROLE pgroles_executor SET createrole_self_grant = 'inherit';
+```
+
+If the connection uses `connection.params.setRole`, configure the login
+identity or the session, not just the target role:
+[`SET ROLE` does not load the target role's settings](https://www.postgresql.org/docs/18/sql-set-role.html).
+Verify `SHOW createrole_self_grant` using the same connection configuration
+as pgroles. pgroles reads this setting; it does not enable it automatically.
+
+Creating a schema owned by another role also needs a usable `SET ROLE` path
+before the schema statement; use `'set, inherit'` when both kinds of authority
+are needed. Membership additions in the manifest run after schema changes and
+default-privilege grants, so they cannot supply those earlier prerequisites.
+Default-privilege revocations run later and can use inherited authority acquired
+by those additions. Preflight checks that membership removals or inheritance
+downgrades do not leave a later revoke without authority.
+
+**Version note:** v0.11.0 preflight rejects new default-privilege owners for
+non-superusers even with this setting. The behavior above requires the fix in
+the upcoming release. On v0.11.0, pre-create the owner and grant the required
+access, bootstrap in two stages, or use a superuser for the atomic first apply.
 
 The friction also shows up in **brownfield** adoption. `CREATEROLE` does not retroactively grant `ADMIN OPTION` on roles that already existed before the executor was created. For every pre-existing role pgroles needs to alter, drop, or manage memberships on, a superuser or existing admin must explicitly grant the executor admin rights:
 
@@ -90,8 +109,8 @@ Steps 1–2 suffice only when the plan needs no additional owner authority.
 Step 3 gives the executor an inheritance path to the owner for default
 privileges and a SET path for schema assignment; grant only the options
 the plan needs. Repeat for each relevant owner. For owners created by the policy,
-use the staged bootstrap above. Step 4 covers pre-existing roles requiring
-administration.
+configure the self-grant setting described above or use staged bootstrap.
+Step 4 covers pre-existing roles requiring administration.
 
 ## Cloud providers
 

--- a/docs/src/pages/docs/executor-privileges.md
+++ b/docs/src/pages/docs/executor-privileges.md
@@ -68,7 +68,12 @@ are needed. Membership additions in the manifest run after schema changes and
 default-privilege grants, so they cannot supply those earlier prerequisites.
 Default-privilege revocations run later and can use inherited authority acquired
 by those additions. Preflight checks that membership removals or inheritance
-downgrades do not leave a later revoke without authority.
+downgrades do not leave a later revoke without authority. A planned membership
+counts toward that authority only if its administrator is the executor or a
+role whose privileges the executor still inherits. SET access alone does not
+suffice. This check is conservative: it does not use newly added administrator
+paths to authorize other additions; split such bootstrap steps into separate
+applies if preflight rejects them.
 
 **Version note:** v0.11.0 preflight rejects new default-privilege owners for
 non-superusers even with this setting. The behavior above requires the fix in

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -175,6 +175,9 @@ the authenticated login/session: `SET ROLE` does not load target-role settings.
 pgroles reads the setting without enabling it. Later default revokes can
 instead use inherited authority established by the plan's membership additions;
 removals and inheritance downgrades must not leave them without authority.
+A planned grant requires a surviving usable administrator, not just membership
+or SET access to one. Preflight conservatively excludes administrator paths
+established by other additions; stage those bootstrap steps separately.
 v0.11.0 preflight rejects new owners even with this setting; this support
 requires the upcoming release. On v0.11.0 pre-create the owner and grant inherited
 membership, or bootstrap separately.

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -167,6 +167,18 @@ is one schema or the owner-wide global layer. A default owner declaration does
 not retroactively grant existing objects and does not cover objects created by
 another role.
 
+When a non-superuser plan creates an owner and grants its defaults before
+membership additions, PostgreSQL 16+ needs `CREATEROLE` and
+`createrole_self_grant = 'inherit'` (or `'set, inherit'`) on the connection
+for immediate inherited authority. `'set'` alone is insufficient. Configure
+the authenticated login/session: `SET ROLE` does not load target-role settings.
+pgroles reads the setting without enabling it. Later default revokes can
+instead use inherited authority established by the plan's membership additions;
+removals and inheritance downgrades must not leave them without authority.
+v0.11.0 preflight rejects new owners even with this setting; this support
+requires the upcoming release. On v0.11.0 pre-create the owner and grant inherited
+membership, or bootstrap separately.
+
 Schema defaults add to the global layer and cannot subtract from it. Removing
 PostgreSQL's built-in `PUBLIC EXECUTE` on functions therefore needs a global
 rule with `ensure: absent`; a schema-scoped one only removes a schema-scoped


### PR DESCRIPTION
A non-superuser with CREATEROLE and createrole_self_grant='inherit' can create a role and alter its default privileges in PostgreSQL 16+, but pgroles v0.11.0 rejects that plan before execution. This fixes the limitation documented in #228.

Preflight now reads the connection's setting and includes newly created roles and automatic inherited grants in its authority model. Early default grants require immediate authority; later default revokes account for membership removals, additions, and INHERIT FALSE downgrades. Planned inheriting additions require an ADMIN grant held by the executor or an administrator it still inherits after removals and downgrades, or automatic ADMIN on a newly created role. Newly added administrator paths cannot establish prerequisites for other additions; this conservative boundary is documented. SET-only access remains insufficient, and pgroles does not enable the setting or grant extra authority itself. The existing conservative treatment of multiple grantors is preserved and documented.

Documentation and the policy skill explain login/session configuration, SET ROLE behavior, schema-owner requirements, revoke-only plans, and the v0.11.0 limitation.

Validation:
- Three sub-agent quality reviews; implementation and documentation re-reviews found no outstanding issues.
- 78 live scenarios on each of PostgreSQL 16, 17, and 18, including existing/missing owners, global/schema scope, membership downgrades, superuser/self-owner controls, exact diagnostics, SQL permission-error assertions, and bridge grants with/without ADMIN OPTION, non-inherited administrators, removed/downgraded admin paths, and independent surviving administrators.
- Existing grantor-authority regression suites pass on all three PostgreSQL versions.
- Workspace tests: 1,061 passed, 104 ignored; the selected live suites above were run explicitly.
- All-target/all-feature Clippy with warnings denied, formatting, diff checks, docs production build, and pinned policy-skill validation pass.

Full Kubernetes/operator E2E coverage remains for CI.


