### PR TITLE
Align candidate grant preservation and batch role-scoped SQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1542,6 +1542,9 @@ jobs:
       # cluster, operator and PostgreSQL, and a second kind cluster would cost
       # several minutes of CI for nothing.
       # ==================================================================
+      - name: Verify candidate grant preservation
+        run: scripts/e2e-candidate-preservation.sh
+
       - name: Run candidate and promotion scenarios
         run: |
           source scripts/e2e-helpers.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Candidate plans apply the same undeclared object-grant preservation filter as normal reconciliation before computing review SQL and approval effects.
+- SQL rendering and execution combine consecutive grantor-specific revocations into shared role blocks, preserving change order and restoring the configured execution role.
+
 - Release notes use only the matching changelog entry, without GitHub's duplicated change list. Missing or empty release notes stop draft creation.
 
 ## [0.11.0] - 2026-09-06

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -1681,31 +1681,23 @@ async fn execute_changes(
         }
     };
 
-    for change in changes {
-        let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
-        for statement in pgroles_core::sql::render_statements_with_context(change, sql_ctx) {
-            let statement_for_error = if is_sensitive {
-                "ALTER ROLE ... PASSWORD [REDACTED]".to_string()
-            } else {
-                statement.clone()
-            };
-            if is_sensitive {
-                info!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
-            } else {
-                info!(sql = %statement, "executing");
-            }
-            if let Err(error) = sqlx::query(&statement).execute(transaction.as_mut()).await {
-                anyhow::bail!(
-                    "{}",
-                    render_execution_failure(
-                        &statement_for_error,
-                        execution_backend.as_ref(),
-                        &error
-                    )
-                );
-            }
+    for statement in pgroles_core::sql::render_batch_with_context(changes, sql_ctx) {
+        info!(sql = %statement.redacted_sql, "executing");
+        if let Err(error) = sqlx::query(&statement.sql)
+            .execute(transaction.as_mut())
+            .await
+        {
+            anyhow::bail!(
+                "{}",
+                render_execution_failure(
+                    &statement.redacted_sql,
+                    execution_backend.as_ref(),
+                    &error
+                )
+            );
         }
     }
+
     transaction
         .commit()
         .await

--- a/crates/pgroles-core/src/sql.rs
+++ b/crates/pgroles-core/src/sql.rs
@@ -152,6 +152,77 @@ pub fn render_statements(change: &Change) -> Vec<String> {
 /// Render a single [`Change`] into one or more SQL statements,
 /// using the given [`SqlContext`] for version-dependent syntax.
 pub fn render_statements_with_context(change: &Change, ctx: &SqlContext) -> Vec<String> {
+    render_batch_with_context(std::slice::from_ref(change), ctx)
+        .into_iter()
+        .map(|statement| statement.sql)
+        .collect()
+}
+
+/// One executable statement and its safe display counterpart.
+///
+/// Keep statements separate when executing: PostgreSQL's prepared query
+/// protocol does not accept a multi-statement script.
+pub struct RenderedStatement {
+    /// Executable SQL, potentially containing a password. Never log this field.
+    pub sql: String,
+    /// The same statement with password values replaced for display or logging.
+    pub redacted_sql: String,
+}
+
+/// Render an ordered plan, sharing role switches across consecutive revokes
+/// attributed to the same grantor. No changes are reordered. Every temporary
+/// role block restores the configured execution role (or the login role).
+/// Password redaction uses change metadata, never SQL text parsing.
+pub fn render_batch_with_context(changes: &[Change], ctx: &SqlContext) -> Vec<RenderedStatement> {
+    let mut result = Vec::new();
+    let mut active_grantor: Option<&str> = None;
+    let restore = || match &ctx.execution_role {
+        Some(role) => format!("SET ROLE {};", quote_ident(role)),
+        None => "RESET ROLE;".to_string(),
+    };
+    let plain = |sql: String| RenderedStatement {
+        redacted_sql: sql.clone(),
+        sql,
+    };
+    for change in changes {
+        // Object REVOKE acts on the current grantor's ACL entry (a superuser
+        // acts as owner); GRANTED BY cannot impersonate another object grantor.
+        // Membership revokes instead express attribution with GRANTED BY and
+        // must continue to execute under the configured connection role.
+        let grantor = match change {
+            Change::Revoke { grantor, .. } => grantor.as_deref(),
+            _ => None,
+        };
+        let statements = render_unscoped_statements(change, ctx);
+        if statements.is_empty() {
+            continue;
+        }
+        if grantor != active_grantor {
+            if active_grantor.is_some() {
+                result.push(plain(restore()));
+            }
+            if let Some(role) = grantor {
+                result.push(plain(format!("SET ROLE {};", quote_ident(role))));
+            }
+            active_grantor = grantor;
+        }
+        for sql in statements {
+            let redacted_sql = match change {
+                Change::SetPassword { name, .. } => {
+                    format!("ALTER ROLE {} PASSWORD '[REDACTED]';", quote_ident(name))
+                }
+                _ => sql.clone(),
+            };
+            result.push(RenderedStatement { sql, redacted_sql });
+        }
+    }
+    if active_grantor.is_some() {
+        result.push(plain(restore()));
+    }
+    result
+}
+
+fn render_unscoped_statements(change: &Change, ctx: &SqlContext) -> Vec<String> {
     match change {
         Change::CreateRole { name, state } => render_create_role(name, state),
         Change::CreateSchema { name, owner } => render_create_schema(name, owner.as_deref()),
@@ -190,14 +261,13 @@ pub fn render_statements_with_context(change: &Change, ctx: &SqlContext) -> Vec<
             object_type,
             schema,
             name,
-            grantor,
+            grantor: _,
         } => render_revoke(
             role,
             privileges,
             *object_type,
             schema.as_deref(),
             name.as_deref(),
-            grantor.as_deref(),
             ctx,
         ),
         Change::SetDefaultPrivilege {
@@ -240,9 +310,9 @@ pub fn render_all(changes: &[Change]) -> String {
 
 /// Render all changes into a single SQL script with version context.
 pub fn render_all_with_context(changes: &[Change], ctx: &SqlContext) -> String {
-    changes
-        .iter()
-        .flat_map(|c| render_statements_with_context(c, ctx))
+    render_batch_with_context(changes, ctx)
+        .into_iter()
+        .map(|statement| statement.sql)
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -482,44 +552,17 @@ fn render_revoke(
     object_type: ObjectType,
     schema: Option<&str>,
     name: Option<&str>,
-    grantor: Option<&str>,
     ctx: &SqlContext,
 ) -> Vec<String> {
-    let privilege_list = format_privileges(privileges);
-    let statements = render_privilege_statements(
+    render_privilege_statements(
         "REVOKE",
         role,
-        &privilege_list,
+        &format_privileges(privileges),
         object_type,
         schema,
         name,
         ctx,
-    );
-    // PostgreSQL's plain REVOKE removes only the ACL entry of the grantor it
-    // selects for the executor (a superuser acts as the owner), and
-    // `GRANTED BY` for object privileges must name the current user — so a
-    // grantor-targeted revoke *becomes* the grantor for its statements. The
-    // whole plan runs in one transaction on one connection, so the SET ROLE
-    // pair brackets exactly these statements. The preflight verifies the
-    // executor can become the grantor before an apply runs. The closing
-    // statement restores the connection's configured execution role when one
-    // is set (e.g. the operator's `connection.params.setRole`, applied via
-    // `SET ROLE` after connect): `RESET ROLE` would reset to the *login*
-    // role instead, silently dropping that boundary for the rest of the plan
-    // and the pooled connection.
-    match grantor {
-        Some(grantor) => {
-            let restore = match &ctx.execution_role {
-                Some(role) => format!("SET ROLE {};", quote_ident(role)),
-                None => "RESET ROLE;".to_string(),
-            };
-            std::iter::once(format!("SET ROLE {};", quote_ident(grantor)))
-                .chain(statements)
-                .chain(std::iter::once(restore))
-                .collect()
-        }
-        None => statements,
-    }
+    )
 }
 
 fn render_privilege_statements(
@@ -1570,6 +1613,94 @@ mod tests {
             sql,
             "GRANT \"inventory-editor\" TO \"noinherit@example.com\" WITH INHERIT FALSE;"
         );
+    }
+
+    #[test]
+    fn batch_preserves_order_role_boundaries_and_redaction() {
+        let revoke = |schema: &str, grantor: &str| Change::Revoke {
+            role: Grantee::Role("reader".into()),
+            privileges: BTreeSet::from([Privilege::Usage]),
+            object_type: ObjectType::Schema,
+            schema: None,
+            name: Some(schema.into()),
+            grantor: Some(grantor.into()),
+        };
+        let changes = vec![
+            revoke("a", "owner"),
+            revoke("b", "owner"),
+            revoke("c", "other"),
+            revoke("d", "owner"),
+            Change::SetPassword {
+                name: "reader".into(),
+                password: "secret".into(),
+            },
+            revoke("e", "owner"),
+        ];
+        let ctx = SqlContext::default().with_execution_role(Some("executor".into()));
+        let batch = render_batch_with_context(&changes, &ctx);
+        let full = batch
+            .iter()
+            .map(|s| s.sql.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(full, render_all_with_context(&changes, &ctx));
+        assert_eq!(
+            full.lines().collect::<Vec<_>>(),
+            vec![
+                "SET ROLE \"owner\";",
+                "REVOKE USAGE ON SCHEMA \"a\" FROM \"reader\";",
+                "REVOKE USAGE ON SCHEMA \"b\" FROM \"reader\";",
+                "SET ROLE \"executor\";",
+                "SET ROLE \"other\";",
+                "REVOKE USAGE ON SCHEMA \"c\" FROM \"reader\";",
+                "SET ROLE \"executor\";",
+                "SET ROLE \"owner\";",
+                "REVOKE USAGE ON SCHEMA \"d\" FROM \"reader\";",
+                "SET ROLE \"executor\";",
+                "ALTER ROLE \"reader\" PASSWORD 'secret';",
+                "SET ROLE \"owner\";",
+                "REVOKE USAGE ON SCHEMA \"e\" FROM \"reader\";",
+                "SET ROLE \"executor\";",
+            ]
+        );
+        assert_eq!(full.matches("SET ROLE \"owner\";").count(), 3);
+        assert_eq!(full.matches("SET ROLE \"executor\";").count(), 4);
+        assert!(full.contains("FROM \"reader\";\nREVOKE USAGE ON SCHEMA \"b\""));
+        assert!(full.contains("SET ROLE \"executor\";\nALTER ROLE"));
+        let redacted = batch
+            .iter()
+            .map(|s| s.redacted_sql.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!redacted.contains("secret"));
+        assert!(redacted.contains("PASSWORD '[REDACTED]'"));
+        assert!(full.contains("secret"));
+        assert!(render_batch_with_context(&[], &ctx).is_empty());
+    }
+
+    #[test]
+    fn batch_keeps_wildcard_expansion_in_one_role_block() {
+        let change = Change::Revoke {
+            role: Grantee::Role("reader".into()),
+            privileges: BTreeSet::from([Privilege::Select]),
+            object_type: ObjectType::Table,
+            schema: Some("app".into()),
+            name: Some("*".into()),
+            grantor: Some("owner".into()),
+        };
+        let ctx = SqlContext::default().with_object_inventory(BTreeMap::from([(
+            (ObjectType::Table, "app".into()),
+            vec!["a".into(), "b".into()],
+        )]));
+        let sql = render_all_with_context(&[change.clone(), change], &ctx);
+        assert_eq!(
+            sql.lines()
+                .filter(|line| line.starts_with("SET ROLE"))
+                .count(),
+            1
+        );
+        assert_eq!(sql.matches("RESET ROLE").count(), 1);
+        assert_eq!(sql.matches("REVOKE SELECT").count(), 4);
     }
 
     #[test]

--- a/crates/pgroles-operator/src/candidate.rs
+++ b/crates/pgroles-operator/src/candidate.rs
@@ -691,17 +691,12 @@ async fn plan_against_target(
              use adopt or authoritative mode to enforce absence"
         );
     }
-    let mut changes = pgroles_core::diff::filter_changes(
-        pgroles_core::diff::apply_role_retirements(
-            pgroles_core::diff::diff(&current, desired),
-            &manifest.retirements,
-        ),
+    let mut changes = crate::reconciler::policy_changes(
+        &current,
+        desired,
+        manifest,
+        expanded,
         reconciliation_mode,
-    );
-    changes = pgroles_core::diff::filter_external_role_changes(
-        changes,
-        &expanded.roles,
-        &expanded.memberships,
     );
 
     // Read-only password resolution. Generated Secrets are named for the
@@ -2071,6 +2066,175 @@ mod tests {
                  active policy's own reconcile"
             );
         }
+    }
+
+    /// Exercise the same effect pipeline used by both planners with candidate
+    /// content: undeclared ACLs are adoption state, not proposed revocations.
+    #[test]
+    fn candidate_preservation_filters_effects_before_sql_and_approval_digest() {
+        use pgroles_core::diff::Change;
+        use pgroles_core::manifest::{ObjectType, Privilege};
+        use pgroles_core::model::{GrantKey, GrantState};
+
+        for preserve in [false, true] {
+            let content: PolicyContent = serde_json::from_value(serde_json::json!({
+                "reconciliationMode": "authoritative",
+                "roles": [{ "name": "app_reader", "preserve_undeclared_grants": preserve }],
+                "grants": [{
+                    "role": "app_reader", "privileges": ["DELETE"], "ensure": "absent",
+                    "object": { "type": "table", "schema": "app", "name": "records" }
+                }]
+            }))
+            .expect("content");
+            let proposal = candidate("reader-change", content);
+            let inputs = candidate_inputs(&proposal, &[]).expect("inputs");
+            let mut current = inputs.desired.clone();
+            current.grant_absences.clear();
+            current.grants.insert(
+                GrantKey {
+                    role: "app_reader".into(),
+                    object_type: ObjectType::Table,
+                    schema: Some("app".into()),
+                    name: Some("records".into()),
+                },
+                GrantState {
+                    privileges: BTreeSet::from([Privilege::Select, Privilege::Delete]),
+                },
+            );
+            let changes = crate::reconciler::policy_changes(
+                &current,
+                &inputs.desired,
+                &inputs.manifest,
+                &inputs.expanded,
+                pgroles_core::diff::ReconciliationMode::Authoritative,
+            );
+            let expected = vec![Change::Revoke {
+                role: "app_reader".into(),
+                object_type: ObjectType::Table,
+                schema: Some("app".into()),
+                name: Some("records".into()),
+                grantor: None,
+                privileges: if preserve {
+                    BTreeSet::from([Privilege::Delete])
+                } else {
+                    BTreeSet::from([Privilege::Select, Privilege::Delete])
+                },
+            }];
+            assert_eq!(changes, expected, "preserve={preserve}");
+            let sql = pgroles_core::sql::render_batch_with_context(
+                &changes,
+                &pgroles_core::sql::SqlContext::default(),
+            )
+            .into_iter()
+            .map(|statement| statement.redacted_sql)
+            .collect::<Vec<_>>()
+            .join("\n");
+            assert!(sql.contains("DELETE"));
+            assert_eq!(sql.contains("SELECT"), !preserve);
+            let digest = |effects: &[Change]| {
+                crate::plan::compute_change_digest(
+                    effects,
+                    crate::crd::CrdReconciliationMode::Authoritative,
+                    "default/database:DATABASE_URL",
+                    &pgroles_core::approval::TargetIdentity {
+                        physical: Some("7412330000000000001".into()),
+                        logical: None,
+                    },
+                    &BTreeMap::new(),
+                    &[],
+                    &[],
+                )
+                .expect("digest")
+            };
+            assert_eq!(digest(&changes), digest(&expected));
+            if preserve {
+                assert_ne!(
+                    digest(&changes),
+                    digest(&pgroles_core::diff::diff(&current, &inputs.desired))
+                );
+                // Once the explicit absence is satisfied, the remaining
+                // undeclared grant produces NoEffects, hence no approval plan.
+                current
+                    .grants
+                    .values_mut()
+                    .next()
+                    .unwrap()
+                    .privileges
+                    .remove(&Privilege::Delete);
+                assert!(
+                    crate::reconciler::policy_changes(
+                        &current,
+                        &inputs.desired,
+                        &inputs.manifest,
+                        &inputs.expanded,
+                        pgroles_core::diff::ReconciliationMode::Authoritative,
+                    )
+                    .is_empty()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn candidate_preservation_keeps_default_and_membership_revocations() {
+        use pgroles_core::diff::{Change, ReconciliationMode};
+        use pgroles_core::manifest::{ObjectType, Privilege};
+        use pgroles_core::model::{DefaultPrivKey, DefaultPrivState, DefaultPrivilegeScope};
+
+        let content: PolicyContent = serde_json::from_value(serde_json::json!({
+            "roles": [{ "name": "reader", "preserve_undeclared_grants": true },
+                      { "name": "owner" }]
+        }))
+        .expect("content");
+        let inputs = candidate_inputs(&candidate("reader-change", content), &[]).expect("inputs");
+        let mut current = inputs.desired.clone();
+        current.memberships.insert(MembershipEdge {
+            role: "owner".into(),
+            member: "reader".into(),
+            inherit: true,
+            admin: false,
+        });
+        current.default_privileges.insert(
+            DefaultPrivKey {
+                owner: "owner".into(),
+                grantee: "reader".into(),
+                scope: DefaultPrivilegeScope::Schema {
+                    schema: "app".into(),
+                },
+                on_type: ObjectType::Table,
+            },
+            DefaultPrivState {
+                privileges: BTreeSet::from([Privilege::Select]),
+            },
+        );
+        let changes = crate::reconciler::policy_changes(
+            &current,
+            &inputs.desired,
+            &inputs.manifest,
+            &inputs.expanded,
+            ReconciliationMode::Authoritative,
+        );
+        assert_eq!(changes.len(), 2);
+        assert!(
+            changes
+                .iter()
+                .any(|change| matches!(change, Change::RevokeDefaultPrivilege { .. }))
+        );
+        assert!(
+            changes
+                .iter()
+                .any(|change| matches!(change, Change::RemoveMember { .. }))
+        );
+        assert!(
+            crate::reconciler::policy_changes(
+                &current,
+                &inputs.desired,
+                &inputs.manifest,
+                &inputs.expanded,
+                ReconciliationMode::Additive,
+            )
+            .is_empty()
+        );
     }
 
     /// The inspection scope of a candidate is the candidate's own — its

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1589,17 +1589,12 @@ pub(crate) async fn execute_changes_in_transaction(
     let mut transaction = pool.begin().await?;
     let mut statements_executed = 0usize;
 
-    for change in changes {
-        let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
-        for sql in pgroles_core::sql::render_statements_with_context(change, sql_context) {
-            if is_sensitive {
-                tracing::debug!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
-            } else {
-                tracing::debug!(%sql, "executing");
-            }
-            sqlx::query(&sql).execute(transaction.as_mut()).await?;
-            statements_executed += 1;
-        }
+    for statement in pgroles_core::sql::render_batch_with_context(changes, sql_context) {
+        tracing::debug!(sql = %statement.redacted_sql, "executing");
+        sqlx::query(&statement.sql)
+            .execute(transaction.as_mut())
+            .await?;
+        statements_executed += 1;
     }
 
     transaction.commit().await?;
@@ -1995,11 +1990,7 @@ pub(crate) fn render_full_sql(
     changes: &[pgroles_core::diff::Change],
     sql_context: &pgroles_core::sql::SqlContext,
 ) -> String {
-    changes
-        .iter()
-        .flat_map(|change| pgroles_core::sql::render_statements_with_context(change, sql_context))
-        .collect::<Vec<_>>()
-        .join("\n")
+    pgroles_core::sql::render_all_with_context(changes, sql_context)
 }
 
 /// Render redacted SQL for display (passwords replaced with [REDACTED]).
@@ -2007,18 +1998,9 @@ fn render_redacted_sql(
     changes: &[pgroles_core::diff::Change],
     sql_context: &pgroles_core::sql::SqlContext,
 ) -> String {
-    changes
-        .iter()
-        .flat_map(|change| {
-            if let pgroles_core::diff::Change::SetPassword { name, .. } = change {
-                vec![format!(
-                    "ALTER ROLE {} PASSWORD '[REDACTED]';",
-                    pgroles_core::sql::quote_ident(name)
-                )]
-            } else {
-                pgroles_core::sql::render_statements_with_context(change, sql_context)
-            }
-        })
+    pgroles_core::sql::render_batch_with_context(changes, sql_context)
+        .into_iter()
+        .map(|statement| statement.redacted_sql)
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -4519,6 +4501,129 @@ mod tests {
             &BTreeSet::new(),
             ORPHAN_GRACE_SECS + 1
         ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live PostgreSQL"]
+    async fn batch_execution_restores_role_and_rolls_back_on_failure() {
+        use pgroles_core::{
+            diff::Change,
+            manifest::{ObjectType, Privilege},
+            model::Grantee,
+        };
+        use sqlx::{
+            Executor,
+            postgres::{PgConnectOptions, PgPoolOptions},
+        };
+        use std::str::FromStr;
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL");
+        let admin = sqlx::PgPool::connect(&url).await.unwrap();
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let login = format!("batch_login_{suffix}");
+        let executor = format!("batch_exec_{suffix}");
+        let owner = format!("batch_owner_{suffix}");
+        let reader = format!("batch_reader_{suffix}");
+        let schema = format!("batch_{suffix}");
+        admin
+            .execute(
+                format!(
+                    r#"
+            CREATE ROLE "{login}" LOGIN NOINHERIT PASSWORD 'batch_password';
+            CREATE ROLE "{executor}" NOINHERIT;
+            CREATE ROLE "{owner}";
+            CREATE ROLE "{reader}";
+            GRANT "{executor}", "{owner}" TO "{login}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{owner}";
+            CREATE TABLE "{schema}".a (id int);
+            CREATE TABLE "{schema}".b (id int);
+            ALTER TABLE "{schema}".a OWNER TO "{owner}";
+            ALTER TABLE "{schema}".b OWNER TO "{owner}";
+            SET ROLE "{owner}";
+            GRANT SELECT ON "{schema}".a, "{schema}".b TO "{reader}";
+            RESET ROLE;
+        "#
+                )
+                .as_str(),
+            )
+            .await
+            .unwrap();
+        let hook_role = executor.clone();
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .after_connect(move |conn, _| {
+                let stmt = format!("SET ROLE {};", pgroles_core::sql::quote_ident(&hook_role));
+                Box::pin(async move {
+                    conn.execute(stmt.as_str()).await?;
+                    Ok(())
+                })
+            })
+            .connect_with(
+                PgConnectOptions::from_str(&url)
+                    .unwrap()
+                    .username(&login)
+                    .password("batch_password"),
+            )
+            .await
+            .unwrap();
+        let revoke = |name: &str| Change::Revoke {
+            role: Grantee::Role(reader.clone()),
+            privileges: BTreeSet::from([Privilege::Select]),
+            object_type: ObjectType::Table,
+            schema: Some(schema.clone()),
+            name: Some(name.into()),
+            grantor: Some(owner.clone()),
+        };
+        let ctx =
+            pgroles_core::sql::SqlContext::default().with_execution_role(Some(executor.clone()));
+        let current = || sqlx::query_scalar::<_, String>("SELECT current_user::text");
+        // The second statement fails inside the shared owner block: transaction
+        // rollback must restore both the first ACL and the connection role.
+        assert!(
+            execute_changes_in_transaction(&pool, &[revoke("a"), revoke("missing")], &ctx)
+                .await
+                .is_err()
+        );
+        assert_eq!(current().fetch_one(&pool).await.unwrap(), executor);
+        let check = format!(
+            r#"SELECT has_table_privilege('{}', '"{}".a', 'SELECT')"#,
+            reader, schema
+        );
+        assert!(
+            sqlx::query_scalar::<_, bool>(&check)
+                .fetch_one(&admin)
+                .await
+                .unwrap()
+        );
+        let changes = vec![revoke("a"), revoke("b")];
+        assert_eq!(
+            render_full_sql(&changes, &ctx),
+            render_redacted_sql(&changes, &ctx)
+        );
+        assert_eq!(
+            execute_changes_in_transaction(&pool, &changes, &ctx)
+                .await
+                .unwrap(),
+            4
+        );
+        assert_eq!(current().fetch_one(&pool).await.unwrap(), executor);
+        for table in ["a", "b"] {
+            let check = format!(
+                r#"SELECT has_table_privilege('{}', '"{}".{}', 'SELECT')"#,
+                reader, schema, table
+            );
+            assert!(
+                !sqlx::query_scalar::<_, bool>(&check)
+                    .fetch_one(&admin)
+                    .await
+                    .unwrap()
+            );
+        }
+        pool.close().await;
+        admin.execute(format!(r#"DROP SCHEMA "{schema}" CASCADE; DROP ROLE "{login}", "{executor}", "{owner}", "{reader}";"#).as_str()).await.unwrap();
+        admin.close().await;
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -224,6 +224,30 @@ pub enum ReconcileError {
 /// work under the locks would abandon an in-flight DDL phase.
 const K8S_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Compute policy effects identically for live reconciliation and candidate previews.
+/// Apply preservation before password injection, summaries, SQL and approval digests.
+pub(crate) fn policy_changes(
+    current: &pgroles_core::model::RoleGraph,
+    desired: &pgroles_core::model::RoleGraph,
+    manifest: &pgroles_core::manifest::PolicyManifest,
+    expanded: &pgroles_core::manifest::ExpandedManifest,
+    reconciliation_mode: pgroles_core::diff::ReconciliationMode,
+) -> Vec<pgroles_core::diff::Change> {
+    let mut changes = pgroles_core::diff::filter_changes(
+        pgroles_core::diff::apply_role_retirements(
+            pgroles_core::diff::diff(current, desired),
+            &manifest.retirements,
+        ),
+        reconciliation_mode,
+    );
+    changes = pgroles_core::diff::filter_external_role_changes(
+        changes,
+        &expanded.roles,
+        &expanded.memberships,
+    );
+    pgroles_core::diff::filter_preserved_grant_revokes(changes, &expanded.roles, desired)
+}
+
 /// Run one pre-lock Kubernetes API call under [`K8S_CALL_TIMEOUT`].
 ///
 /// `call` names the request in the log and in the resulting status condition,
@@ -1435,22 +1459,12 @@ async fn apply_under_lock(
         );
     }
     let diff_started = std::time::Instant::now();
-    let mut changes = pgroles_core::diff::filter_changes(
-        pgroles_core::diff::apply_role_retirements(
-            pgroles_core::diff::diff(&current, &effective_desired),
-            &manifest.retirements,
-        ),
-        reconciliation_mode,
-    );
-    changes = pgroles_core::diff::filter_external_role_changes(
-        changes,
-        &expanded.roles,
-        &expanded.memberships,
-    );
-    changes = pgroles_core::diff::filter_preserved_grant_revokes(
-        changes,
-        &expanded.roles,
+    let mut changes = policy_changes(
+        &current,
         &effective_desired,
+        manifest,
+        expanded,
+        reconciliation_mode,
     );
 
     let plan_warnings = plan_advisory_warnings(

--- a/docs/src/pages/docs/operator-candidates.md
+++ b/docs/src/pages/docs/operator-candidates.md
@@ -46,14 +46,22 @@ others.
 
 ## Preview limitations
 
-In v0.11.0, candidate planning does not run every enforcing-policy check:
+Candidate planning applies the same `preserve_undeclared_grants` filter as the
+normal reconciler before generating SQL, the change summary, and the approval
+digest. The setting comes from the candidate's proposed roles. It preserves
+undeclared object grants; explicit object absence assertions, default privileges,
+and memberships retain their normal reconciliation semantics. If only preserved
+grants differ, the candidate reports `Ready=True` with reason `NoEffects` and
+creates no approval plan.
 
-- It omits the `preserve_undeclared_grants` filter, so it can preview object
-  revokes that the parent would suppress after promotion.
-- It omits executor-authority preflight, plan advisory warnings, and the adopt
-  mode schema-owner-transfer guard. `Ready=True` means a preview is available;
-  it does not prove the executor can apply it. Execution settings such as
-  `allow_schema_owner_transfers` remain on the parent, outside candidate content.
+In v0.11.0, candidate planning omitted this filter and could preview revokes that
+the parent would suppress after promotion. This is fixed in the next release.
+
+Candidate planning still omits executor-authority preflight, plan advisory
+warnings, and the adopt-mode schema-owner-transfer guard. `Ready=True` means a
+preview is available; it does not prove the executor can apply it. Execution
+settings such as `allow_schema_owner_transfers` remain on the parent, outside
+candidate content.
 
 Promotion recomputes effects and checks the approved digest before execution.
 Different effects require a replacement plan; matching effects can still be

--- a/docs/src/pages/docs/operator-plan-approval.md
+++ b/docs/src/pages/docs/operator-plan-approval.md
@@ -145,6 +145,18 @@ produces exactly one new plan, and re-planning an unchanged source produces
 the same digest every time. `status.sqlHash` still exists, but only as a
 diagnostic for the preview text; it is never the approval gate.
 
+Full SQL, redacted previews, and execution share the same batch renderer.
+Consecutive object revokes attributed to the same grantor share one `SET ROLE`
+block. A different grantor or an ordinary statement closes the block, restoring
+`connection.params.setRole` when configured, or using `RESET ROLE` otherwise.
+The renderer preserves change order; it does not gather non-adjacent operations
+by role. Passwords remain redacted in previews and execution logs.
+
+This formatting can change SQL hashes and statement counts without changing the
+semantic approval digest. The candidate preservation fix is different: removing
+an undeclared revoke changes the effects, so an old approval cannot authorize a
+different recomputed plan.
+
 Because identity is semantic, plans survive irrelevant change. A policy
 generation bump, an unrelated base edit, or unrelated ephemeral-access
 activity re-plans to an identical digest and the pending plan — including a

--- a/scripts/e2e-candidate-preservation.sh
+++ b/scripts/e2e-candidate-preservation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Requires the plan-lifecycle E2E cluster, operator and postgres-credentials.
+# Uses actual candidate status/SQL, so bypassing the shared effect pipeline
+# cannot be hidden by the pure planning tests.
+set -euo pipefail
+source "$(dirname "$0")/e2e-helpers.sh"
+
+pg_query 'CREATE SCHEMA candidate_preserve; CREATE TABLE candidate_preserve.records(id integer);'
+kubectl apply -f - <<'YAML'
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: candidate-preserve-policy
+spec:
+  connection:
+    secretRef:
+      name: postgres-credentials
+  interval: "5s"
+  mode: apply
+  approval: auto
+  roles:
+    - name: candidate_preserve_reader
+      preserve_undeclared_grants: true
+  grants:
+    - role: candidate_preserve_reader
+      privileges: [SELECT]
+      object: {type: table, schema: candidate_preserve, name: records}
+YAML
+wait_for_ready_true candidate-preserve-policy
+pg_query 'GRANT DELETE ON candidate_preserve.records TO candidate_preserve_reader;'
+
+file_preservation_candidate() {
+  local name="$1" preserve="$2" explicit="$3"
+  python3 - "$name" "$preserve" "$explicit" <<'PY' | kubectl apply -f -
+import json
+import sys
+name, preserve, explicit = sys.argv[1:]
+content = {
+    "roles": [{"name": "candidate_preserve_reader", "preserve_undeclared_grants": preserve == "true"}],
+    "grants": [{"role": "candidate_preserve_reader", "privileges": ["SELECT"],
+                "object": {"type": "table", "schema": "candidate_preserve", "name": "records"}}],
+}
+if explicit == "true":
+    content["grants"].append({"role": "candidate_preserve_reader", "privileges": ["DELETE"],
+                              "ensure": "absent", "object": content["grants"][0]["object"]})
+print(json.dumps({"apiVersion": "pgroles.io/v1alpha1", "kind": "PostgresPolicyCandidate",
+                  "metadata": {"name": name}, "spec": {
+                      "policyRef": {"name": "candidate-preserve-policy"}, "content": content}}))
+PY
+}
+
+file_preservation_candidate candidate-preserve-kept true false
+wait_for_candidate_condition candidate-preserve-kept Ready True NoEffects
+test -z "$(kubectl get pgcand candidate-preserve-kept -o jsonpath='{.status.planRef.name}')"
+
+previous_digest=""
+for name in candidate-preserve-off candidate-preserve-explicit; do
+  if [ "$name" = candidate-preserve-off ]; then
+    file_preservation_candidate "$name" false false
+  else
+    file_preservation_candidate "$name" true true
+  fi
+  wait_for_candidate_phase "$name" Planned
+  plan="$(wait_for_candidate_plan_ref "$name")"
+  test "$(kubectl get pgplan "$plan" -o jsonpath='{.status.changeSummary.grants_revoked}')" = 1
+  sql="$(get_plan_sql "$plan")"
+  [[ "$sql" == *'REVOKE DELETE ON TABLE "candidate_preserve"."records" FROM "candidate_preserve_reader";'* ]]
+  [[ "$sql" != *'REVOKE SELECT'* ]]
+  digest="$(kubectl get pgplan "$plan" -o jsonpath='{.status.changeDigest}')"
+  test -n "$digest"
+  if [ -n "$previous_digest" ]; then
+    test "$digest" = "$previous_digest"
+  fi
+  previous_digest="$digest"
+done
+
+# Planning is read-only, and the live policy keeps the undeclared privilege.
+test "$(pg_query "SELECT has_table_privilege('candidate_preserve_reader', 'candidate_preserve.records', 'DELETE');")" = t
+kubectl delete pgcand candidate-preserve-kept candidate-preserve-off candidate-preserve-explicit
+kubectl delete pgr candidate-preserve-policy --wait=true
+pg_query 'DROP SCHEMA candidate_preserve CASCADE; DROP ROLE candidate_preserve_reader;'
+echo 'Candidate preservation, explicit absence and read-only planning passed.'

--- a/skills/pgroles-operator/SKILL.md
+++ b/skills/pgroles-operator/SKILL.md
@@ -225,12 +225,15 @@ Interpretation:
 - `Ready=False, reason=BlockedByActivePolicy` means the parent is failing or
   has its own plan awaiting a decision; the candidate is planned once the
   parent settles.
-- In v0.11.0, candidate planning omits the `preserve_undeclared_grants`
-  filter, executor-authority preflight, advisory warnings, and adopt-mode
-  schema-owner-transfer guard. It can preview revokes the parent suppresses;
-  `Ready=True` does not prove apply will succeed. Check executor authority and
-  parent execution settings separately. Changed effects require a replacement
-  plan at promotion; the approved digest does not bypass execution checks.
+- Candidate planning filters undeclared object-grant revokes using the proposed
+  roles' `preserve_undeclared_grants` setting, before SQL and approval digest
+  generation. Explicit absence, default privileges, and memberships retain their
+  normal semantics. v0.11.0 omitted this filter; the next release fixes that gap.
+- Candidate planning still omits executor-authority preflight, advisory warnings,
+  and the adopt-mode schema-owner-transfer guard. `Ready=True` does not prove
+  apply will succeed. Check executor authority and parent execution settings
+  separately. Changed effects require a replacement plan at promotion; the
+  approved digest does not bypass execution checks.
 - The spec is immutable. Revise by filing a successor that names this
   candidate in `spec.replaces`.
 - Approving the candidate's plan executes nothing by itself. Execution happens


### PR DESCRIPTION
Candidate previews could propose undeclared object-grant revocations that normal reconciliation suppresses with `preserve_undeclared_grants: true`. This fixes that mismatch and makes SQL easier to review by combining consecutive revokes under the same grantor.

### Candidate preview matches preservation settings

For example, a role declares `SELECT` on `app.records` with `preserve_undeclared_grants: true`, while the database also grants it `DELETE`.

**Before:** the candidate preview proposed revoking the undeclared privilege, even though normal reconciliation would preserve it:

```sql
SET ROLE "app_owner";
REVOKE DELETE ON TABLE "app"."records" FROM "app_reader";
RESET ROLE;
```

**After:** that revoke is filtered out before the summary, SQL, and approval digest are generated. If it is the only difference, the candidate reports `Ready=True`, reason `NoEffects`, and creates no approval plan. Setting preservation to `false`, or explicitly declaring `DELETE` with `ensure: absent`, still proposes the revoke.

Candidate and live planning now share the same effect-filtering pipeline, using the candidate's proposed role definitions. Default privileges, memberships, and reconciliation modes retain their existing semantics.

### Consecutive revokes share a role block

For revokes that remain in the plan, the renderer previously switched roles around each individual change.

**Before:**

```sql
SET ROLE "app_owner";
REVOKE SELECT ON TABLE "app"."records" FROM "app_reader";
RESET ROLE;
SET ROLE "app_owner";
REVOKE SELECT ON TABLE "app"."archive" FROM "app_reader";
RESET ROLE;
```

**After:**

```sql
SET ROLE "app_owner";
REVOKE SELECT ON TABLE "app"."records" FROM "app_reader";
REVOKE SELECT ON TABLE "app"."archive" FROM "app_reader";
RESET ROLE;
```

Full SQL, redacted previews, and operator/CLI execution consume the same batch renderer. Change order is preserved: a different grantor or an ordinary executable statement closes the block. When an execution role is configured, restoration uses `SET ROLE` for that role instead of `RESET ROLE`. Password redaction comes from change metadata rather than SQL parsing.

Batching can change diagnostic SQL hashes and statement counts without changing semantic approval identity. Filtering a previously proposed revoke changes the effects and remains subject to normal plan revalidation and approval rules.

### Validation

- Full workspace suite: 1,065 tests passed; 103 ignored by the default run. Clippy and formatting passed.
- SQL regression tests cover exact ordering, role boundaries, password redaction, and wildcard expansion.
- A PostgreSQL 18 test uses a non-superuser connection to verify role restoration, actual ACL changes, and rollback after failure inside a shared role block.
- An actual Kubernetes/operator E2E test checks preservation on/off, explicit absence, persisted SQL and summary, equivalent-effect digests, `NoEffects`, and read-only planning. This regression is added to CI.
- Candidate/approval documentation, the operator skill, and changelog are updated; documentation build and skill validation passed.
